### PR TITLE
Fix typos

### DIFF
--- a/Documentation/old_doc/Guide/ofxExample4_Saturation.adoc
+++ b/Documentation/old_doc/Guide/ofxExample4_Saturation.adoc
@@ -67,7 +67,7 @@ Both of these have rules associated as to how the plugin behaves in that context
 simple, most of the default behaviour just works and you don't have to trap many other actions.
 
 In the case of the general context, the default behaviour might not work the way you want, and you 
-may have to trap other actions. Fortunately the defaults work for us as wll.
+may have to trap other actions. Fortunately the defaults work for us as well.
 
 [source, c++]
 .saturation.cpp

--- a/Documentation/sources/Guide/Code/Example1/basics.cpp
+++ b/Documentation/sources/Guide/Code/Example1/basics.cpp
@@ -105,7 +105,7 @@ namespace {
 
 
   ////////////////////////////////////////////////////////////////////////////////
-  // House keeper to make sure we are loaded and unloaded symetrically
+  // House keeper to make sure we are loaded and unloaded symmetrically
   bool gInLoadedState = false;
   bool gDescribeCalled = false;
   bool gDescribeInContextCalled = false;
@@ -120,7 +120,7 @@ namespace {
 
     /// now fetch a suite out of the host via it's fetch suite function.
     gPropertySuite = (OfxPropertySuiteV1 *) gHost->fetchSuite(gHost->host, kOfxPropertySuite, 1);
-    ERROR_ABORT_IF(gPropertySuite == 0, "Failed to fetch the " kOfxPropertySuite " verison 1 from the host.");
+    ERROR_ABORT_IF(gPropertySuite == 0, "Failed to fetch the " kOfxPropertySuite " version 1 from the host.");
 
     gImageEffectSuite = (OfxImageEffectSuiteV1 *) gHost->fetchSuite(gHost->host, kOfxImageEffectSuite, 1);
 

--- a/Documentation/sources/Guide/Code/Example2/invert.cpp
+++ b/Documentation/sources/Guide/Code/Example2/invert.cpp
@@ -104,10 +104,10 @@ namespace {
   {
     /// now fetch a suite out of the host via it's fetch suite function.
     gPropertySuite = (OfxPropertySuiteV1 *) gHost->fetchSuite(gHost->host, kOfxPropertySuite, 1);
-    ERROR_ABORT_IF(gPropertySuite == 0, "Failed to fetch the " kOfxPropertySuite " verison 1 from the host.");
+    ERROR_ABORT_IF(gPropertySuite == 0, "Failed to fetch the " kOfxPropertySuite " version 1 from the host.");
 
     gImageEffectSuite = (OfxImageEffectSuiteV1 *) gHost->fetchSuite(gHost->host, kOfxImageEffectSuite, 1);
-    ERROR_ABORT_IF(gImageEffectSuite == 0, "Failed to fetch the " kOfxImageEffectSuite " verison 1 from the host.");
+    ERROR_ABORT_IF(gImageEffectSuite == 0, "Failed to fetch the " kOfxImageEffectSuite " version 1 from the host.");
 
     return kOfxStatOK;
   }
@@ -383,7 +383,7 @@ namespace {
       bool isAborting = gImageEffectSuite->abort(instance);
 
       // if we were interrupted, the failed fetch is fine, just return kOfxStatOK
-      // otherwise, something wierd happened
+      // otherwise, something weird happened
       if(!isAborting) {
         status = kOfxStatFailed;
       }

--- a/Documentation/sources/Guide/Code/Example3/gain.cpp
+++ b/Documentation/sources/Guide/Code/Example3/gain.cpp
@@ -150,7 +150,7 @@ namespace {
     suite = (SUITE *) gHost->fetchSuite(gHost->host, suiteName, suiteVersion);
     if(!suite) {
       ERROR_ABORT_IF(suite == NULL,
-                     "Failed to fetch %s verison %d from the host.",
+                     "Failed to fetch %s version %d from the host.",
                      suiteName,
                      suiteVersion);
     }
@@ -568,7 +568,7 @@ namespace {
       bool isAborting = gImageEffectSuite->abort(instance);
 
       // if we were interrupted, the failed fetch is fine, just return kOfxStatOK
-      // otherwise, something wierd happened
+      // otherwise, something weird happened
       if(!isAborting) {
         status = kOfxStatFailed;
       }

--- a/Documentation/sources/Guide/Code/Example4/saturation.cpp
+++ b/Documentation/sources/Guide/Code/Example4/saturation.cpp
@@ -175,7 +175,7 @@ namespace {
     }
   }
 
-  // assemble it all togther
+  // assemble it all together
   void Image::construct()
   {
     if(propSet_) {
@@ -313,7 +313,7 @@ namespace {
     suite = (SUITE *) gHost->fetchSuite(gHost->host, suiteName, suiteVersion);
     if(!suite) {
       ERROR_ABORT_IF(suite == NULL,
-                     "Failed to fetch %s verison %d from the host.",
+                     "Failed to fetch %s version %d from the host.",
                      suiteName,
                      suiteVersion);
     }
@@ -710,7 +710,7 @@ namespace {
       bool isAborting = gImageEffectSuite->abort(instance);
 
       // if we were interrupted, the failed fetch is fine, just return kOfxStatOK
-      // otherwise, something wierd happened
+      // otherwise, something weird happened
       if(!isAborting) {
         status = kOfxStatFailed;
       }

--- a/Documentation/sources/Guide/Code/Example5/circle.cpp
+++ b/Documentation/sources/Guide/Code/Example5/circle.cpp
@@ -202,7 +202,7 @@ namespace {
     }
   }
 
-  // assemble it all togther
+  // assemble it all together
   void Image::construct()
   {
     if(propSet_) {
@@ -346,7 +346,7 @@ namespace {
     suite = (SUITE *) gHost->fetchSuite(gHost->host, suiteName, suiteVersion);
     if(!suite) {
       ERROR_ABORT_IF(suite == NULL,
-                     "Failed to fetch %s verison %d from the host.",
+                     "Failed to fetch %s version %d from the host.",
                      suiteName,
                      suiteVersion);
     }
@@ -835,7 +835,7 @@ namespace {
       bool isAborting = gImageEffectSuite->abort(instance);
 
       // if we were interrupted, the failed fetch is fine, just return kOfxStatOK
-      // otherwise, something wierd happened
+      // otherwise, something weird happened
       if(!isAborting) {
         status = kOfxStatFailed;
       }

--- a/Documentation/sources/Guide/TODO.txt
+++ b/Documentation/sources/Guide/TODO.txt
@@ -5,7 +5,7 @@ The following examples should be added to the guide.
 
 OpenGL Overlay Example
 ======================
-A trival example along the lines of the circle drawing example.
+A trivial example along the lines of the circle drawing example.
 
 This will illustrate...
     - openGL overlays
@@ -45,7 +45,7 @@ This will illustrate...
 
 Analysis Plugin
 ===============
-The plugin will find the minumum and maximum value of a given frame in response to a push button, and store the values
+The plugin will find the minimum and maximum value of a given frame in response to a push button, and store the values
 into two parameters. During renders it will rescale pixel values so that 'min' is 0 and 'max' is the whitepoint.
 
 This will illustrate...

--- a/Documentation/sources/Guide/ofxExample2_Invert.rst
+++ b/Documentation/sources/Guide/ofxExample2_Invert.rst
@@ -232,7 +232,7 @@ listed below.
 
 :c:macro:`kOfxImageComponentRGB` Each pixel has three samples, corresponding to Red, Green and Blue. Packed as RGB.
 
-:c:macro:`kOfxImageComponentAlpha` Each pixel has one sample, generally interpretted as an Alpha value.
+:c:macro:`kOfxImageComponentAlpha` Each pixel has one sample, generally interpreted as an Alpha value.
 
 .. note::
 
@@ -508,7 +508,7 @@ written to.
 
 The output image (which will be fetched later on) will have a **bounds**
 that are at least as big as the render window. The bounds of the output
-image could infact be larger. This could happen if a host is
+image could in fact be larger. This could happen if a host is
 simultaneously calling the render action in separate threads to perform
 symmetric multi-processing, each thread would be given a different
 render window to fill in of the larger output image.

--- a/Documentation/sources/Guide/ofxExample3_Gain.rst
+++ b/Documentation/sources/Guide/ofxExample3_Gain.rst
@@ -97,7 +97,7 @@ looks like:
         suite = (SUITE *) gHost->fetchSuite(gHost->host, suiteName, suiteVersion);
         if(!suite) {
           ERROR_ABORT_IF(suite == NULL,
-                         "Failed to fetch %s verison %d from the host.",
+                         "Failed to fetch %s version %d from the host.",
                          suiteName,
                          suiteVersion);
         }
@@ -228,7 +228,7 @@ value, so the parameter should not be clamped to any upper value ever.
 
 Numbers are often manipulated with sliders widgets in user interfaces,
 and it is useful to set a range on those sliders. Which is exactly what
-we are doing here. This is distinct to the logical mimimum and maximum
+we are doing here. This is distinct to the logical minimum and maximum
 values, so you can set a *useful* range for the UI, but still allow the
 values to be outside that range. So here a slider would only allow
 values between 0.0 and 10.0 for our gain param, but the parameter could
@@ -462,7 +462,7 @@ The param get value functions use var-args to return values to plugins,
 similar to a C scanf function.
 
 And finally here is a snippet of the templated pixel pushing code where
-we do the actuall processing using our parameter values;
+we do the actual processing using our parameter values;
 
 `gain.cpp <https://github.com/ofxa/openfx/blob/doc/Documentation/sources/Guide/Code/Example3/gain.cpp#L437>`_
 

--- a/Documentation/sources/Guide/ofxExample4_Saturation.rst
+++ b/Documentation/sources/Guide/ofxExample4_Saturation.rst
@@ -38,7 +38,7 @@ of inputs and the rules for certain behaviours are relaxed.
 So you’ve written your OFX effect, and it can work with a single input,
 but would ideally work much better with multiple inputs. You also want
 it to work as best it can across a range of host applications. If you
-could only write it as a multi-input generall effect with more than one
+could only write it as a multi-input general effect with more than one
 input, it couldn’t work in an editor. However if you wrote it as a
 single input effect, it wouldn’t work as well as it could in a node
 based compositor. Having your effect work in multiple contexts is the
@@ -84,7 +84,7 @@ behaviour just works and you don’t have to trap many other actions.
 
 In the case of the general context, the default behaviour might not work
 the way you want, and you may have to trap other actions. Fortunately
-the defaults work for us as wll.
+the defaults work for us as well.
 
 `saturation.cpp <https://github.com/ofxa/openfx/blob/doc/Documentation/sources/Guide/Code/Example4/saturation.cpp#388>`_
 
@@ -173,7 +173,7 @@ clip and call it "Mask". We then tell the host about that clip…
 
 -  secondly, that the clip is optional,
 
--  thirdly, that this clip is to be interpretted as a mask, so hosts
+-  thirdly, that this clip is to be interpreted as a mask, so hosts
    that manage such things separately, know it can be fed into this
    input.
 
@@ -262,7 +262,7 @@ mask input.
 We are again using instance data to cache away a set of handles to clips
 and params (the constructor of which sets them all to NULL). We are also
 recording which context we have had our instance created for by checking
-the :c:macro:`kOfxImageEffectPropContext` property of the efect. If it is a
+the :c:macro:`kOfxImageEffectPropContext` property of the effect. If it is a
 general context we also cache the *Mask* input in our instance data.
 Pretty easy.
 
@@ -272,7 +272,7 @@ Rendering
 ---------
 
 Because we are now using a class to wrap up OFX images (see
-:ref:`below <a_bit_of_houskeeping>`) the render code is a bit tidier but
+:ref:`below <a_bit_of_housekeeping>`) the render code is a bit tidier but
 is pretty much still the same really. The major difference is that we
 are now fetching a third image, for the mask image, and we are prepared
 for this to fail and keep going as we may be in the filter context, or
@@ -363,7 +363,7 @@ we may be in the general context but the clip is not connected.
           bool isAborting = gImageEffectSuite->abort(instance);
 
           // if we were interrupted, the failed fetch is fine, just return kOfxStatOK
-          // otherwise, something wierd happened
+          // otherwise, something weird happened
           if(!isAborting) {
             status = kOfxStatFailed;
           }
@@ -463,9 +463,9 @@ this is not meant to be fast code, just illustrative.
         }
       }
 
-.. _a_bit_of_houskeeping:
+.. _a_bit_of_housekeeping:
 
-A Bit Of Houskeeping
+A Bit Of Housekeeping
 ====================
 
 You may have noticed I’ve gone and created an ``Image`` class. I got
@@ -542,4 +542,3 @@ types on input and output clips.
 
 .. [1]
    provided you stick to the conditions listed at the top of source file
-

--- a/Documentation/sources/Guide/ofxExample5_Circle.rst
+++ b/Documentation/sources/Guide/ofxExample5_Circle.rst
@@ -392,7 +392,7 @@ function now has an extra conditional in there….
         }
         ...
 
-Note that we dont trap this on hosts that aren’t multi-resolution, as by
+Note that we don't trap this on hosts that aren’t multi-resolution, as by
 definition on those hosts RoDs are fixed.
 
 The code for the action itself is quite simple:

--- a/Documentation/sources/Guide/ofxExamples.rst
+++ b/Documentation/sources/Guide/ofxExamples.rst
@@ -63,7 +63,7 @@ one. You should work through them one by one as each will build on the
 one before.
 
 For completeness and clarity of explanation, each plugin is entirely
-self contained and has no dependancy on anything other than standard C
+self contained and has no dependency on anything other than standard C
 and C++ libraries and the OFX headers.
 
 -  :ref:`The basic machinery of an OFX plugin. <basicExample>`

--- a/Documentation/sources/Reference/apiChanges_1_2_Chapter.rst
+++ b/Documentation/sources/Reference/apiChanges_1_2_Chapter.rst
@@ -14,7 +14,7 @@ plugin written to an earlier API.
 Packaging
 ---------
 
-A new architecture directory was added to the bundle heirarchy to
+A new architecture directory was added to the bundle hierarchy to
 specifically contain Mac OSX 64 bit builds. The current 'MacOS'
 architecture is a fall back for 32 bit only and/or universal binary
 builds.
@@ -71,7 +71,7 @@ New Syncing Property
 A new property has been added to parameter sets,
 :c:macro:`kOfxPropParamSetNeedsSyncing`. This
 is used by plugins with internal data structures that need syncing back
-to parameters for persistance and so on. This property should be set
+to parameters for persistence and so on. This property should be set
 whenever the plugin changes it's internal state to inform the host that
 a sync will be required before the next serialisation of the plugin.
 Without this property, the host would have to continually force the
@@ -89,7 +89,7 @@ plugin would prefer to be sequentially rendered if possible, but need
 not be.
 
 The :c:macro:`kOfxImageEffectInstancePropSequentialRender`
-propery has also been added to the host descriptor, to indicate whether
+property has also been added to the host descriptor, to indicate whether
 the host can support sequential rendering.
 
 The new property :c:macro:`kOfxImageEffectPropSequentialRenderStatus`

--- a/Documentation/sources/Reference/ofxClipPreferences.rst
+++ b/Documentation/sources/Reference/ofxClipPreferences.rst
@@ -21,7 +21,7 @@ clip, some on both. These are...
 -  the fielding of the output clip,
 -  the premultiplication state of the output clip,
 -  whether the output clip varys from frame to frame, even if no
-   paramerters or input images change over time,
+   parameters or input images change over time,
 -  whether the output clip can be sampled at sub-frame times and produce
    different images.
 
@@ -209,7 +209,7 @@ The default value of the output clip's fielding is host dependant, but
 in general,
 
 -  if any of the input clips are fielded, so will the output clip
--  the output clip may be fielded irregardless of the input clips (for
+-  the output clip may be fielded regardless of the input clips (for
    example, in a fielded project).
 
 If the host allows a plugin to specify the fielding of the output clip,
@@ -250,7 +250,7 @@ frames on output.
        FIELDED SOURCE      0.0 0.5 1.0 1.5 2.0 2.5 3.0 3.5 4.0 4.5 ....
        DEINTELACED OUTPUT  0   1   2   3   4   5   6   7   8   9 
 
-The maping of the number of output frames is...
+The mapping of the number of output frames is...
 
 ::
 

--- a/Documentation/sources/Reference/ofxCoordSystem.rst
+++ b/Documentation/sources/Reference/ofxCoordSystem.rst
@@ -20,7 +20,7 @@ has three spatial coordinate systems
 -  The Pixel Coordinate System
    which describes coordinates in addressable pixels
 -  The Normalised Canonical Coordinate System
-   which allows for resolution independant description of parameters
+   which allows for resolution independent description of parameters
 
 .. _CanonicalCoordinates:
 Canonical Coordinates
@@ -51,7 +51,7 @@ ratio of 1.067 and a scale factor of 0.5f. We call this the **Pixel
 Coordinate System**.
 
 The Pixel coordinate system is always referenced by integer values,
-generally via a OfxRectI structure. It is used when refering to
+generally via a OfxRectI structure. It is used when referring to
 operations on actual pixels, and so is how the bounds of images are
 described and the render window passed to the render action.
 
@@ -129,7 +129,7 @@ be in the bottom left hand corner, which is probably not the correct
 spot.
 
 To get around this, OFX allows parameters to be flagged as *normalised*,
-which is a resolution independant method of representing spatial
+which is a resolution independent method of representing spatial
 coordinates. In this coordinate system, a point expressed as (0.5, 0.5)
 will appear in the centre of the screen, always.
 
@@ -147,7 +147,7 @@ explanation. It involves three two dimensional values...
    a 16:9 PAL SD project
 
 As described above, the project extent is the section of the image plane
-that is coverred by an image that is the desired output of the project,
+that is covered by an image that is the desired output of the project,
 so for a PAL SD project you get an extent of 0,0 to 768,576. As the
 project is always rooted at the origin, so the extent is actually a
 size.
@@ -262,7 +262,7 @@ property can take are...
    position on the image plane, deprecated for 1.2.
 
 For example, we have an effect that draws a circle. It has two
-parameters a 1D double radius parametere and a 2D double position
+parameters a 1D double radius parameters and a 2D double position
 parameter. It would flag the radius to be
 :c:macro:`kOfxParamDoubleTypeNormalisedX`, fetch the value and scale that by
 the project size before we render the circle. The host should present
@@ -291,7 +291,7 @@ second being last the time at which the clip will generate data.
 
 Consider the example below, it is showing an effect of 10 frames
 duration applied to a clip lasting 20 frames. The first frame of the
-effect is infact the 5th frame of the clip. Both the input and output
+effect is in fact the 5th frame of the clip. Both the input and output
 have the same frame rate.
 
     ::

--- a/Documentation/sources/Reference/ofxCoreAPI.rst
+++ b/Documentation/sources/Reference/ofxCoreAPI.rst
@@ -12,7 +12,7 @@ OFX Include Files
 
 The *C* include files that define an OFX API are all that are needed by
 a plug-in or host to implement the API. Most include files define a set
-of independant *suites* which are used by a plug-in to communicate with
+of independent *suites* which are used by a plug-in to communicate with
 a host application.
 
 There are two include files that are used with nearly every derived API.
@@ -79,8 +79,8 @@ host needs to implement is defined by the API being implemented. A suite
 is fetched from a host via the :cpp:func:`OfxHost::fetchSuite` function. This
 returns a pointer (cast to ``void *``) to the named and versioned set of
 functions. By using this suite fetching mechanism, there is no symbolic
-dependancy from the plug-in to the host, and APIs can be easily
-expandable without causing backwards compatability issues.
+dependency from the plug-in to the host, and APIs can be easily
+expandable without causing backwards compatibility issues.
 
 If the host does not implement a requested suite, or the requested
 version of that suite, then it should return NULL.
@@ -128,7 +128,7 @@ one of the following...
 
 Label strings are considered to be static constant strings. When passed
 across the API the host/plug-in receiving the string neither needs to
-duplicate nor free the string, it can simply retain the orginal pointer
+duplicate nor free the string, it can simply retain the original pointer
 passed over and use that in future, as it will not change. A host must
 be aware that when it unloads a plug-in all such pointers will be
 invalid, and be prepared to cope with such a situation.

--- a/Documentation/sources/Reference/ofxImageClip.rst
+++ b/Documentation/sources/Reference/ofxImageClip.rst
@@ -66,7 +66,7 @@ t he bounds are the actual addressable pixels present in an image. This
 allows for tiled rendering an so on.
 
 Clips have a frame rate, which is the number of frames per second they
-are to be displayed at. Some clips may be continously samplable (for
+are to be displayed at. Some clips may be continuously samplable (for
 example, if they are connected to animating geometry that can be
 rendered at arbitrary times), if this is so, the frame rate for these
 clips is set to 0.
@@ -87,7 +87,7 @@ define the clips mandated for that context, it can also define extra
 clips that it may need for that context. It does this using the
 :cpp:func`OfxImageEffectSuiteV1::clipDefine`
 function, the property handle returned by this function is purely for
-definition purposes only. It has not persistance outside the describe in
+definition purposes only. It has not persistence outside the describe in
 context action and is distinct to the clip property handles used by
 instances. The *name* parameter is how you can later access that clip in
 a plugin instance via the
@@ -143,7 +143,7 @@ Images are fetched from a clip via the
 :cpp:func:`OfxImageEffectSuiteV1::clipGetImage`
 function. This takes a time and an optional region to extract an image
 at from a given clip. This returns, in a property handle, an image
-fetched from the clip at a specfic time. The handle contains all the
+fetched from the clip at a specific time. The handle contains all the
 information relevant to dealing with that image.
 
 Once fetched, an image must be released via the

--- a/Documentation/sources/Reference/ofxImageEffectActions.rst
+++ b/Documentation/sources/Reference/ofxImageEffectActions.rst
@@ -13,8 +13,8 @@ from two categories...
    `ofxImageEffect.h <https://github.com/ofxa/openfx/blob/master/include/ofxImageEffect.h>`_
 
 For generic actions, the ``handle`` passed to to main entry point will
-depend on the API being impemented, for all generic actions passed to an
-OFX Image Effect plug-in, it will nearly alway be an
+depend on the API being implemented, for all generic actions passed to an
+OFX Image Effect plug-in, it will nearly always be an
 :cpp:class:`OfxImageEffectHandle`.
 
 Because interacts are a special case, they are dealt with in a separate

--- a/Documentation/sources/Reference/ofxImageEffectContexts.rst
+++ b/Documentation/sources/Reference/ofxImageEffectContexts.rst
@@ -311,6 +311,6 @@ example) or explicit (with a curve).
 Similarly with the 'SourceTime' double parameter in the retimer context.
 It is up to the host to provide a UI for this, either implicitly (say by
 stretching a clip's length on the time line) or via an explicit curve.
-Note that the host is not limitted to using a UI that exposes the
+Note that the host is not limited to using a UI that exposes the
 'SourceTime' as a curve, alternately it could present a 'speed'
 parameter, and integrate that to derive a value for 'SourceTime'.

--- a/Documentation/sources/Reference/ofxPackaging.rst
+++ b/Documentation/sources/Reference/ofxPackaging.rst
@@ -77,7 +77,7 @@ Where...
 -  ARCHITECTURE is the specific operating system architecture the
    plug-in was built for, these are currently...
 
-   -  MacOS - for Apple Macintosh OS X 32 bit and/or univeral binaries
+   -  MacOS - for Apple Macintosh OS X 32 bit and/or universal binaries
    -  MacOS-x86-64 - for Apple Macintosh OS X, specifically on intel x86
       CPUs running AMD's 64 bit extensions. 64 bit host applications
       should check this first, and if it doesn't exist or is empty, fall

--- a/Documentation/sources/Reference/ofxParameter.rst
+++ b/Documentation/sources/Reference/ofxParameter.rst
@@ -9,7 +9,7 @@ behaviour, the radius of a circle drawer, the frequencies to filter out
 of an audio signal, the colour of a lens flare and so on.
 
 Seeing as hosts already provide for the general management of their own
-native parameters (eg: persistance, interface, animation etc...), it
+native parameters (eg: persistence, interface, animation etc...), it
 would make no sense to force plug-ins to do this all themselves.
 
 The OFX Parameters Suite is the means by which parameters are defined
@@ -53,7 +53,7 @@ The handle returned by
 :cpp:func:`OfxParameterSuiteV1::paramGetHandle`
 outside of a describe action will be a working instance of a parameter,
 you can still set (some) properties of the parameter, and all the
-get/set value functions are now useable.
+get/set value functions are now usable.
 
 .. _parameterTypes:
 
@@ -453,22 +453,22 @@ Rather than have many undo events appear on the undo stack for each
 individual parameter change, the effect groups them via the
 paramEditBegin/paramEditEnd and gets a single undo event. The 'preset'
 parameter would also not want to be undoable as it such an event is
-redunant. Note that as the 'preset' has been changed it will be sent
+redundant. Note that as the 'preset' has been changed it will be sent
 another instance changed action, however it will have a reason of
 :c:macro:`kOfxChangePluginEdited`, which it ignores and so stops an infinite
-loop occuring.
+loop occurring.
 
 .. ParametersXML:
 
 XML Resource Specification for Parameters
 -----------------------------------------
 
-Parameters can have various properties overriden via a seperate XML
+Parameters can have various properties overridden via a separate XML
 based resource file.
 
 .. ParametersPersistance:
 
-Parameter Persistance
+Parameter Persistence
 ---------------------
 
 All parameters flagged with the
@@ -487,7 +487,7 @@ When an host loads a set up it should do so in the following manner...
    should be used.
 3. creates an instance of that plugin with its set of parameters.
 4. sets all those parameters to the defaults specified by the plugin.
-5. examines the setup for any persistant parameters, then sets the
+5. examines the setup for any persistent parameters, then sets the
    instance's parameters to any found in it.
 6. calls create instance on the plugin.
 
@@ -604,7 +604,7 @@ Angle Double Parameters
 
 Double parameters with their
 :c:macro:`kOfxParamPropDoubleType` property set
-to :c:macro:`kOfxParamDoubleTypeAngle` are interpretted as angles. The host
+to :c:macro:`kOfxParamDoubleTypeAngle` are interpreted as angles. The host
 could use some fancy angle widget in it's interface, representing
 degrees, angles mils whatever. However, the values returned to a plugin
 are always in degrees. Applicable to 1, 2 and 3D parameters.
@@ -618,7 +618,7 @@ Scale Double Parameters
 
 Double parameters with their
 :c:macro:`kOfxParamPropDoubleType` property set
-to :c:macro:`kOfxParamDoubleTypeScale` are interpretted as scale factors. The
+to :c:macro:`kOfxParamDoubleTypeScale` are interpreted as scale factors. The
 host can represent these as 1..100 percentages, 0..1 scale factors,
 fractions or whatever is appropriate for its interface. However, the
 plugin sees these as a straight scale factor, in the 0..1 range.
@@ -634,8 +634,8 @@ Time Double Parameters
 
 Double parameters with their
 :c:macro:`kOfxParamPropDoubleType` property set
-to :c:macro:`kOfxParamDoubleTypeTime` are interpretted as a time. The host can
-represent these as frames, seconds, milliseconds, millenia or whatever
+to :c:macro:`kOfxParamDoubleTypeTime` are interpreted as a time. The host can
+represent these as frames, seconds, milliseconds, millennia or whatever
 it feels is appropriate. However, a visual effect plugin sees such
 values in 'frames'. Applicable only to 1D double parameters. It is an
 error to set this on any other type of double parameter.
@@ -650,9 +650,9 @@ Absolute Time Double Parameters
 
 Double parameters with their
 :c:macro:`kOfxParamPropDoubleType` property set
-to :c:macro:`kOfxParamDoubleTypeAbsoluteTime` are interpretted as an absolute
-time from the begining of the effect. The host can represent these as
-frames, seconds, milliseconds, millenia or whatever it feels is
+to :c:macro:`kOfxParamDoubleTypeAbsoluteTime` are interpreted as an absolute
+time from the beginning of the effect. The host can represent these as
+frames, seconds, milliseconds, millennia or whatever it feels is
 appropriate. However, a plugin sees such values in 'frames' from the
 beginning of a clip. Applicable only to 1D double parameters. It is an
 error to set this on any other type of double parameter.
@@ -668,7 +668,7 @@ Spatial Parameters
 Parameters that can represent a size or position are essential. To that
 end there are several values of the
 :c:macro:`kOfxParamPropDoubleType` that say it
-should be interpretted as a size or position, in either one or two
+should be interpreted as a size or position, in either one or two
 dimensions.
 
 The original OFX API only specified
@@ -694,7 +694,7 @@ Spatial Double Parameters
 These parameter types represent a size or position in one or two
 dimensions in :ref:`Canonical Coordinate <CanonicalCoordinates>`. The host
 and plug-in get and set values in this coordinate system. Scaling to
-:ref:`Pixel Coordinate <PixelCoordinates>` is the reponsibility of the
+:ref:`Pixel Coordinate <PixelCoordinates>` is the responsibility of the
 effect.
 
 The default value of a spatial parameter can be set in either a
@@ -733,7 +733,7 @@ available.
 
 There are several values of the
 :c:macro:`kOfxParamPropDoubleType` that say it
-should be interpretted as a size or position. These are expressed and
+should be interpreted as a size or position. These are expressed and
 proportional to the current project's size. This will allow the
 parameter to scale cleanly with project size changes and to be
 represented to the user in an appropriate range.
@@ -776,7 +776,7 @@ In all cases double parameters' defaults, minimums and maximums are
 specified in the same space as the parameter, as is the increment in all
 cases but normalised parameters.
 
-Normalised parameters specify thier increments in cannonical
+Normalised parameters specify their increments in cannonical
 coordinates, rather than in normalised coordinates. So an increment of
 '1' means 1 pixel, not '1 project width', otherwise sliders would be a
 bit wild.
@@ -791,7 +791,7 @@ Parametric Parameters
 Introduction
 ^^^^^^^^^^^^
 
-Parametric params are new for 1.2 and are optinally supported by host
+Parametric params are new for 1.2 and are optionally supported by host
 applications. They are specified via the :c:macro:`kOfxParamTypeParametric`
 identifier passed into
 :cpp:func:`OfxParameterSuiteV1::paramDefine`
@@ -869,7 +869,7 @@ property
 Getting and Setting Values on a Parametric Parameters
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Seeing as we need to pass in the parametric position and dimenstion to
+Seeing as we need to pass in the parametric position and dimension to
 evaluate, parametric parameters need a new evaluation mechanism. They do
 this with the
 :cpp:func:`OfxParametricParameterSuiteV1::parametricParamGetValue` function.

--- a/Documentation/sources/Reference/ofxProcessingArch.rst
+++ b/Documentation/sources/Reference/ofxProcessingArch.rst
@@ -69,7 +69,7 @@ for both double and integer rects. Hosts and plug-ins need to be
 infinite RoD aware. Hosts need to clip such RoDs to an appropriate
 rectangle, typically the project extent. Plug-ins need to check for
 infinite RoDs when asking input clips for them and to pass them through
-unless they explictly clamp them. To indicate an infinite RoD set it as
+unless they explicitly clamp them. To indicate an infinite RoD set it as
 indicated in the following code snippet.
 
     ::
@@ -175,7 +175,7 @@ but always pass around full RoD images, never tiles.
 
 The simplest systems, don't have any of of the above complexity. The
 RoDs, RoIs, images and project sizes in such systems are exactly the
-same, always. Often these are editting, as opposed to compositing,
+same, always. Often these are editing, as opposed to compositing,
 systems.
 
 Similarly, some plugin effects cannot handle sub RoD images, or even
@@ -184,7 +184,7 @@ images not rooted at the origin.
 The OFX architecture is meant to support all of them. Assuming a plugin
 supports the most general architecture, it will trivially run on hosts
 with simpler architectures. However, if a plugin does not support tiled,
-or arbitarily positioned images, they may not run cleanly on hosts that
+or arbitrarily positioned images, they may not run cleanly on hosts that
 expect them to do so.
 
 To this end, two properties are provided that flag the capabilities of a

--- a/Documentation/sources/Reference/ofxRendering.rst
+++ b/Documentation/sources/Reference/ofxRendering.rst
@@ -94,7 +94,7 @@ Indicating that any instance of a plugin can have multiple renders running simul
 
 .. ImageEffectsSMPRendering:
 
-Rendering in a Symetric Multi Processing Enviroment
+Rendering in a Symmetric Multi Processing Environment
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 When rendering on computers that have more that once CPU (or this
@@ -138,7 +138,7 @@ single instance.
 
 Other plugins are able to render correctly when called in an arbitrary
 frame order, but render much more efficiently if rendered in order. For
-example a particle system which mantains the state of the particle
+example a particle system which maintains the state of the particle
 system in an instance would simply increment the simulation by a frame
 if rendering in-order, but would need to restart the particle system
 from scratch if the frame jumped backwards.
@@ -163,7 +163,7 @@ For plug-ins this can be one of three values...
 -  1, in which case the host must render an instance on a single
    computer over it's entire frame range, from first to last.
 -  2, in which case the effect is more efficiently rendered in frame
-   order, but can compute the correct result irregardless of render
+   order, but can compute the correct result regardless of render
    order.
 
 For hosts, this property takes three values...
@@ -202,7 +202,7 @@ must support fast scrubbing. These allow a plug-in to take short-cuts
 for improved performance when the situation allows and it makes sense,
 for example to generate thumbnails with effects applied. For example
 switch to a cheaper interpolation type or rendering mode. A plugin
-should expect frames rendered in this manner that will not be stucked in
+should expect frames rendered in this manner that will not be stuck in
 host cache unless the cache is only used in the same draft situations.
 
 .. _ImageEffectsFieldRendering:
@@ -237,11 +237,11 @@ The material is unfielded
 
 .. doxygendefine:: kOfxImageFieldLower
 
-The material is fielded, with scan line 0,2,4.... occuring first in a frame
+The material is fielded, with scan line 0,2,4.... occurring first in a frame
 
 .. doxygendefine:: kOfxImageFieldUpper
 
-The material is fielded, with scan line 1,3,5.... occuring first in a frame
+The material is fielded, with scan line 1,3,5.... occurring first in a frame
 
 Images extracted from a clip flag what their fieldedness is with the
 property :c:macro:`kOfxImagePropField`, this can
@@ -368,7 +368,7 @@ Any host with an interface will most likely have an interactive thread
 and a rendering thread. This allows an effect to be manipulated while
 having renders batched off to a background thread. This will mean that
 some degree of locking will go on to prevent simultaneous read/writes
-occuring, see :ref:`this section <ImageEffectsThreadSafety>` for more on thread safety.
+occurring, see :ref:`this section <ImageEffectsThreadSafety>` for more on thread safety.
 
 A host may need to abort a backgrounded render, typically in response to
 a user changing a parameter value. An effect should occasionally poll

--- a/Documentation/sources/Reference/ofxStatusCodes.rst
+++ b/Documentation/sources/Reference/ofxStatusCodes.rst
@@ -4,7 +4,7 @@ Status Codes
 ============
 
 Status codes are returned by most functions in OFX suites and all
-plug-in actions to indicate the sucess or failure of the operation. All
+plug-in actions to indicate the success or failure of the operation. All
 status codes are defined in `ofxCore.h <https://github.com/ofxa/openfx/blob/master/include/ofxCore.h>`_ and 
 *#defined* to be integers.
 

--- a/Documentation/sources/Reference/ofxStructure.rst
+++ b/Documentation/sources/Reference/ofxStructure.rst
@@ -22,7 +22,7 @@ link against.
 
 Hosts rely on two symbols within a plug-in, all other communication is
 boot strapped from those two symbols. The plug-in has no symbolic
-dependancies from the host. This minimal symbolic dependancy allows for
+dependencies from the host. This minimal symbolic dependency allows for
 run-time determination of what features to provide over the API, making
 implementation much more flexible and less prone to backwards
 compatibility problems.
@@ -62,7 +62,7 @@ Various suites and actions have been defined for the OFX image effect
 API, however many are actually quite generic and could be reused by
 other APIs. The property suite definitely has to be used by all other
 APIs, while the memory allocation suite, the parameter suite and several
-others would propably be useful for all other APIs. For example the
+others would probably be useful for all other APIs. For example the
 paramter suite could be re-used to specify user visible parameters to
 the other APIs.
 
@@ -78,7 +78,7 @@ allows the implementation of the object to be hidden from the plug-in.
 
 *  :ref:`OfxStatus<statusCodes>`
 
-   Used to define a set of status codes indicating the sucess or
+   Used to define a set of status codes indicating the success or
    failure of an action or suite function
    
 *  :ref:`OfxHost<OfxHost>`
@@ -122,7 +122,7 @@ The OFX Image Effect API.
 
 The OFX Image Effect Plug-in API is designed for image effect plug-ins
 for 2D visual effects. This includes such host applications as
-compositors, editors, rotoscoping tools and colour grading sytems.
+compositors, editors, rotoscoping tools and colour grading systems.
 
 At heart the image effect API allows a host to send a plug-in a set of
 images, state the value of a set of parameters and get a resulting image

--- a/Examples/Basic/basic.cpp
+++ b/Examples/Basic/basic.cpp
@@ -103,7 +103,7 @@ struct MyInstanceData {
 /* mandatory function to set up the host structures */
 
 
-// Convinience wrapper to get private data 
+// Convenience wrapper to get private data 
 static MyInstanceData *
 getMyInstanceData( OfxImageEffectHandle effect)
 {
@@ -118,7 +118,7 @@ getMyInstanceData( OfxImageEffectHandle effect)
   return myData;
 }
 
-// Convinience wrapper to set the enabledness of a parameter
+// Convenience wrapper to set the enabledness of a parameter
 static inline void
 setParamEnabledness( OfxImageEffectHandle effect,
                     const char *paramName,
@@ -136,7 +136,7 @@ setParamEnabledness( OfxImageEffectHandle effect,
   gPropHost->propSetInt(paramProps,  kOfxParamPropEnabled, 0, enabledState);
 }
 
-// function thats sets the enabledness of the percomponent scale parameters
+// function that sets the enabledness of the perComponent scale parameters
 // depending on the value of the 
 // This function is called when the 'scaleComponents' value is changed
 // or when the input clip has been changed
@@ -146,7 +146,7 @@ setPerComponentScaleEnabledness( OfxImageEffectHandle effect)
   // get my instance data
   MyInstanceData *myData = getMyInstanceData(effect);
 
-  // get the value of the percomponent scale param
+  // get the value of the perComponent scale param
   int perComponentScale;
   gParamHost->paramGetValue(myData->perComponentScaleParam, &perComponentScale);
 
@@ -701,7 +701,7 @@ static OfxStatus render( OfxImageEffectHandle  instance,
       throw OfxuStatusException(kOfxStatErrImageFormat);
     }
 
-    // are we compenent scaling
+    // are we component scaling
     int scaleComponents;
     gParamHost->paramGetValueAtTime(myData->perComponentScaleParam, time, &scaleComponents);
 
@@ -787,7 +787,7 @@ static OfxStatus render( OfxImageEffectHandle  instance,
   }
   catch(OfxuNoImageException &ex) {
     // if we were interrupted, the failed fetch is fine, just return kOfxStatOK
-    // otherwise, something wierd happened
+    // otherwise, something weird happened
     if(!gEffectHost->abort(instance)) {
       status = kOfxStatFailed;
     }
@@ -807,7 +807,7 @@ static OfxStatus render( OfxImageEffectHandle  instance,
   return status;
 }
 
-// convience function to define scaling parameter
+// convenience function to define scaling parameter
 static void
 defineScaleParam( OfxParamSetHandle effectParams,
                  const char *name,

--- a/Examples/Cuda/cuda.cpp
+++ b/Examples/Cuda/cuda.cpp
@@ -101,7 +101,7 @@ struct MyInstanceData {
 /* mandatory function to set up the host structures */
 
 
-// Convinience wrapper to get private data
+// Convenience wrapper to get private data
 static MyInstanceData *
 getMyInstanceData( OfxImageEffectHandle effect)
 {
@@ -467,7 +467,7 @@ static OfxStatus render( OfxImageEffectHandle  instance,
   return status;
 }
 
-// convience function to define parameters
+// convenience function to define parameters
 static void
 defineParam( OfxParamSetHandle effectParams,
 	     const char *name,

--- a/Examples/DepthConverter/depthConverter.cpp
+++ b/Examples/DepthConverter/depthConverter.cpp
@@ -87,7 +87,7 @@ struct MyInstanceData {
 };
 
 
-// Convinience wrapper to get private data 
+// Convenience wrapper to get private data 
 static MyInstanceData *
 getMyInstanceData(OfxImageEffectHandle effect)
 {
@@ -387,7 +387,7 @@ static OfxStatus render(OfxImageEffectHandle effect,
   }
   catch(OfxuNoImageException &ex) {
     // if we were interrupted, the failed fetch is fine, just return kOfxStatOK
-    // otherwise, something wierd happened
+    // otherwise, something weird happened
     if(!gEffectHost->abort(effect)) {
       status = kOfxStatFailed;
     }
@@ -504,7 +504,7 @@ describe(OfxImageEffectHandle  effect)
   gPropHost->propGetDimension(gHost->host, kOfxImageEffectPropSupportedPixelDepths, &nHostDepths);
 
   // If the host cannot support multiple bit depths on in and out clips or it only supports 1 bit depth
-  // we cant do any work, so refuse to load and explain why.
+  // we can't do any work, so refuse to load and explain why.
   if(!hostSupportsMultipleDepths || nHostDepths == 1) {
     // post a message
     // - disabled, because posting a message within describe() crashes Nuke 6

--- a/Examples/Invert/invert.cpp
+++ b/Examples/Invert/invert.cpp
@@ -160,7 +160,7 @@ static OfxStatus render(OfxImageEffectHandle  instance,
   }
   catch(NoImageEx &) {
     // if we were interrupted, the failed fetch is fine, just return kOfxStatOK
-    // otherwise, something wierd happened
+    // otherwise, something weird happened
     if(!gEffectHost->abort(instance)) {
       status = kOfxStatFailed;
     }      

--- a/Examples/OpenCL/oclplugin.cpp
+++ b/Examples/OpenCL/oclplugin.cpp
@@ -105,7 +105,7 @@ struct MyInstanceData {
 /* mandatory function to set up the host structures */
 
 
-// Convinience wrapper to get private data
+// Convenience wrapper to get private data
 static MyInstanceData *
 getMyInstanceData( OfxImageEffectHandle effect)
 {
@@ -514,7 +514,7 @@ static OfxStatus render( OfxImageEffectHandle  instance,
   return status;
 }
 
-// convience function to define parameters
+// convenience function to define parameters
 static void
 defineParam( OfxParamSetHandle effectParams,
 	     const char *name,

--- a/Examples/OpenGL/opengl.cpp
+++ b/Examples/OpenGL/opengl.cpp
@@ -117,7 +117,7 @@ struct MyInstanceData {
 /* mandatory function to set up the host structures */
 
 
-// Convinience wrapper to get private data
+// Convenience wrapper to get private data
 static MyInstanceData *
 getMyInstanceData( OfxImageEffectHandle effect)
 {
@@ -474,7 +474,7 @@ static OfxStatus render( OfxImageEffectHandle  instance,
   return status;
 }
 
-// convience function to define parameters
+// convenience function to define parameters
 static void
 defineParam( OfxParamSetHandle effectParams,
 	     const char *name,

--- a/Examples/README.txt
+++ b/Examples/README.txt
@@ -15,7 +15,7 @@ The current examples are all written in C++ and are...
 	         respond to user interaction.
      - Overlay - shows how to draw a simple overlay widget using the OFX Interact
                  API.
-     - Custom  - shows how custom paramters work within the API, it also uses the
+     - Custom  - shows how custom parameters work within the API, it also uses the
 	         OFX Interact API.
      - DepthConverter - shows how to deal with pixel preferences.
      - Rectangle - example generator and filter that shows how to deal with spatial

--- a/Examples/Rectangle/rectangle.cpp
+++ b/Examples/Rectangle/rectangle.cpp
@@ -98,7 +98,7 @@ struct MyInstanceData {
 /* mandatory function to set up the host structures */
 
 
-// Convinience wrapper to get private data 
+// Convenience wrapper to get private data 
 static MyInstanceData *
 getMyInstanceData(OfxImageEffectHandle effect)
 {
@@ -730,7 +730,7 @@ static OfxStatus render(OfxImageEffectHandle effect,
   }
   catch(OfxuNoImageException &ex) {
     // if we were interrupted, the failed fetch is fine, just return kOfxStatOK
-    // otherwise, something wierd happened
+    // otherwise, something weird happened
     if(!gEffectHost->abort(effect)) {
       status = kOfxStatFailed;
     }

--- a/Examples/Test/ofxLog.H
+++ b/Examples/Test/ofxLog.H
@@ -13,7 +13,7 @@ namespace OFX {
   /** @brief Gets the name of the log file. */
   const std::string & logGetFileName();
 
-  /** @brief Opens the log file, returns whether this was sucessful or not. */
+  /** @brief Opens the log file, returns whether this was successful or not. */
   bool logOpenFile(void);
 
   /** @brief Closes the log file. */

--- a/Examples/Test/ofxLog.cpp
+++ b/Examples/Test/ofxLog.cpp
@@ -22,7 +22,7 @@ namespace OFX {
     return gLogFileName;
   }
 
-  /** @brief Opens the log file, returns whether this was sucessful or not. */
+  /** @brief Opens the log file, returns whether this was successful or not. */
   bool
   logOpenFile(void)
   {

--- a/Examples/Test/testProperties.cpp
+++ b/Examples/Test/testProperties.cpp
@@ -31,7 +31,7 @@
 /** @file testProperties.cpp Ofx host testing plug-in which logs all the needed properties
     
 the log file is being written with ';' ending lines and execution blocks surrounded by { } pairs, so if you
-run it through a c beautifier or emacs auto formating, automagic indenting will occur.
+run it through a c beautifier or emacs auto formatting, automagic indenting will occur.
 */
 #include <string> // stl strings
 #include <map> // stl maps
@@ -107,7 +107,7 @@ public :
   OfxStatus propGetN(const char *property, double *values, int N) const;
   OfxStatus propGetN(const char *property, std::string *values, int N) const;
   
-  // these check for existance and dimensionality
+  // these check for existence and dimensionality
   OfxStatus propGetDimension(const char *property, int &size) const;
   
   // inc/dec the log flag to enable/disable ordinary message logging
@@ -836,7 +836,7 @@ HostDescription::HostDescription(OfxPropertySetHandle handle) :
 {
   OFX::logPrint("HostDescription::HostDescription - start ( fetching host description);\n{");
   
-  // do basic existance checking with a PropertySetDescription
+  // do basic existence checking with a PropertySetDescription
   PropertySetDescription hostPropSet("Host", handle, gHostPropDescription, sizeof(gHostPropDescription)/sizeof(PropertyDescription));
   hostPropSet.checkProperties();
   hostPropSet.checkDefaults();
@@ -1295,7 +1295,7 @@ OfxGetNumberOfPlugins(void)
 }
 
 ////////////////////////////////////////////////////////////////////////////////
-// globals desctructor, the destructor is called when the plugin is unloaded
+// globals destructor, the destructor is called when the plugin is unloaded
 class GlobalDestructor {
 public :
   ~GlobalDestructor();

--- a/Examples/XML/example.xml
+++ b/Examples/XML/example.xml
@@ -16,7 +16,7 @@ Bruno Nicoletti
 <OfxPlugin name="someplugin">
 
   <!--
-    Define the resouces overrides to be used for the host 'someHost' in the locale 'someLocale'
+    Define the resources overrides to be used for the host 'someHost' in the locale 'someLocale'
    -->
   <OfxResourceSet ofxHost="someHost" ofxLocale="someLocale">
 

--- a/Examples/include/ofxUtilities.H
+++ b/Examples/include/ofxUtilities.H
@@ -58,7 +58,7 @@ ofxuIsUnPremultiplied(OfxImageClipHandle clipHandle)
 }
 
 
-// Convinience wrapper to check for connection of a clip
+// Convenience wrapper to check for connection of a clip
 inline bool
 ofxuIsClipConnected(OfxImageEffectHandle pluginInstance, const char *clipName)
 {

--- a/Examples/include/osxDeploy.sh
+++ b/Examples/include/osxDeploy.sh
@@ -113,7 +113,7 @@ if otool -L "$binary"  | grep -F libMagick > /dev/null; then
     IMAGEMAGICKMAJ=${IMAGEMAGICKVER%.*.*}
     IMAGEMAGICKLIB=$(pkg-config --variable=libdir ImageMagick)
     IMAGEMAGICKSHARE=$(pkg-config --variable=prefix ImageMagick)/share
-    # if I get this right, sed substitutes in the exe the occurences of IMAGEMAGICKVER
+    # if I get this right, sed substitutes in the exe the occurrences of IMAGEMAGICKVER
     # into the actual value retrieved from the package.
     # We don't need this because we use MAGICKCORE_PACKAGE_VERSION declared in the <magick/magick-config.h>
     # sed -e "s,IMAGEMAGICKVER,$IMAGEMAGICKVER,g" -i "" $pkgbin/DisparityKillerM

--- a/HostSupport/include/ofxhBinary.h
+++ b/HostSupport/include/ofxhBinary.h
@@ -77,7 +77,7 @@ namespace OFX
 
     ~Binary() { unload(); }
 
-    // calls stat, returns true if successfull, false otherwise
+    // calls stat, returns true if successful, false otherwise
     static bool getFileModTimeAndSize(const std::string &binaryPath, time_t& modificationTime, off_t& fileSize);
 
     bool isLoaded() const { return _dlHandle != 0; }

--- a/HostSupport/include/ofxhClip.h
+++ b/HostSupport/include/ofxhClip.h
@@ -150,8 +150,8 @@ namespace OFX {
       protected:
         ImageEffect::Instance*  _effectInstance; ///< image effect instance
         bool  _isOutput;                         ///< are we the output clip
-        std::string             _pixelDepth;     ///< what is the bit depth we is at. Set during the clip prefernces action.
-        std::string             _components;     ///< what components do we have.  Set during the clip prefernces action.
+        std::string             _pixelDepth;     ///< what is the bit depth we is at. Set during the clip preferences action.
+        std::string             _components;     ///< what components do we have.  Set during the clip preferences action.
         
       public:
         ClipInstance(ImageEffect::Instance* effectInstance, ClipDescriptor& desc);
@@ -288,8 +288,8 @@ namespace OFX {
         /// Field Order - Which spatial field occurs temporally first in a frame.
         /// \returns 
         ///  - kOfxImageFieldNone - the clip material is unfielded
-        ///  - kOfxImageFieldLower - the clip material is fielded, with image rows 0,2,4.... occuring first in a frame
-        ///  - kOfxImageFieldUpper - the clip material is fielded, with image rows line 1,3,5.... occuring first in a frame
+        ///  - kOfxImageFieldLower - the clip material is fielded, with image rows 0,2,4.... occurring first in a frame
+        ///  - kOfxImageFieldUpper - the clip material is fielded, with image rows line 1,3,5.... occurring first in a frame
         virtual const std::string &getFieldOrder() const = 0;
         
         // Connected -
@@ -310,7 +310,7 @@ namespace OFX {
         // Continuous Samples -
         //
         //  0 if the images can only be sampled at discreet times (eg: the clip is a sequence of frames),
-        //  1 if the images can only be sampled continuously (eg: the clip is infact an animating roto spline and can be rendered anywhen). 
+        //  1 if the images can only be sampled continuously (eg: the clip is in fact an animating roto spline and can be rendered anywhen). 
         virtual bool getContinuousSamples() const = 0;
 
         /// override this to fill in the image at the given time.
@@ -375,7 +375,7 @@ namespace OFX {
         virtual OfxRectD getRegionOfDefinition(OfxTime time) const = 0;
 
         /// given the colour component, find the nearest set of supported colour components
-        /// override this for extra wierd custom component depths
+        /// override this for extra weird custom component depths
         virtual const std::string &findSupportedComp(const std::string &s) const;
       };
 
@@ -395,7 +395,7 @@ namespace OFX {
         ImageBase();
 
         /// construct from a clip instance, but leave the
-        /// filling it to the calling code via the propery set
+        /// filling it to the calling code via the property set
         explicit ImageBase(ClipInstance& instance);
 
         // Render Scale (renderScaleX,renderScaleY) -
@@ -469,7 +469,7 @@ namespace OFX {
         Image();
 
         /// construct from a clip instance, but leave the
-        /// filling it to the calling code via the propery set
+        /// filling it to the calling code via the property set
         explicit Image(ClipInstance& instance);
 
         // Render Scale (renderScaleX,renderScaleY) -
@@ -534,7 +534,7 @@ namespace OFX {
         Texture();
 
         /// construct from a clip instance, but leave the
-        /// filling it to the calling code via the propery set
+        /// filling it to the calling code via the property set
         explicit Texture(ClipInstance& instance);
 
         // Render Scale (renderScaleX,renderScaleY) -

--- a/HostSupport/include/ofxhImageEffect.h
+++ b/HostSupport/include/ofxhImageEffect.h
@@ -173,7 +173,7 @@ namespace OFX {
         /// override this to use your own memory instance - must inherrit from memory::instance
         virtual Memory::Instance* newMemoryInstance(size_t nBytes);
 
-        // return an memory::instance calls makeMemoryInstance that can be overriden
+        // return an memory::instance calls makeMemoryInstance that can be overridden
         Memory::Instance* imageMemoryAlloc(size_t nBytes);
       };
 
@@ -511,7 +511,7 @@ namespace OFX {
         /// params and input images are exactly the same. eg: random noise generator
         bool isFrameVarying() const {return _frameVarying;}
 
-        /// pure virtuals that must  be overriden
+        /// pure virtuals that must  be overridden
         virtual ClipInstance* getClip(const std::string& name) const;
 
         /// override this to make processing abort, return 1 to abort processing
@@ -520,7 +520,7 @@ namespace OFX {
         /// override this to use your own memory instance - must inherrit from memory::instance
         virtual Memory::Instance* newMemoryInstance(size_t nBytes);
 
-        // return an memory::instance calls makeMemoryInstance that can be overriden
+        // return an memory::instance calls makeMemoryInstance that can be overridden
         Memory::Instance* imageMemoryAlloc(size_t nBytes);
 
         /// make a clip
@@ -552,10 +552,10 @@ namespace OFX {
         /// overridden from Property::Notify
         virtual void notify(const std::string &name, bool singleValue, int indexOrN) OFX_EXCEPTION_SPEC;
 
-        /// overridden from gethook,  get the virutals for viewport size, pixel scale, background colour
+        /// overridden from gethook,  get the virtuals for viewport size, pixel scale, background colour
         virtual double getDoubleProperty(const std::string &name, int index) const OFX_EXCEPTION_SPEC;
 
-        /// overridden from gethook,  get the virutals for viewport size, pixel scale, background colour
+        /// overridden from gethook,  get the virtuals for viewport size, pixel scale, background colour
         virtual void getDoublePropertyN(const std::string &name, double *values, int count) const OFX_EXCEPTION_SPEC;
 
         virtual const std::string &getStringProperty(const std::string &name, int index) const  OFX_EXCEPTION_SPEC;
@@ -590,7 +590,7 @@ namespace OFX {
 
         // The extent of the current project in canonical coordinates. 
         // The extent is the size of the 'output' for the current project. See ProjectCoordinateSystems 
-        // for more infomation on the project extent. The extent is in canonical coordinates and only 
+        // for more information on the project extent. The extent is in canonical coordinates and only 
         // returns the top right position, as the extent is always rooted at 0,0. For example a PAL SD 
         // project would have an extent of 768, 576. 
         virtual void getProjectExtent(double& xSize, double& ySize) const = 0;
@@ -877,7 +877,7 @@ namespace OFX {
         virtual void setDefaultClipPreferences();
 
         /// Initialise the clip preferences arguments, override this to do
-        /// stuff with wierd components etc... Calls setDefaultClipPreferences
+        /// stuff with weird components etc... Calls setDefaultClipPreferences
         virtual void setupClipPreferencesArgs(Property::Set &args);
 
         /// Run the clip preferences action from the effect.

--- a/HostSupport/include/ofxhInteract.h
+++ b/HostSupport/include/ofxhInteract.h
@@ -105,7 +105,7 @@ namespace OFX {
       };
 
       /// a generic interact, it doesn't belong to anything in particular
-      /// we need to generify this slighty more and remove the renderscale args
+      /// we need to generify this slightly more and remove the renderscale args
       /// into a derived class, as they only belong to image effect plugins
       class Instance : public Base, protected Property::GetHook {
       protected:
@@ -190,7 +190,7 @@ namespace OFX {
         // don't know what to do
         virtual void reset(const std::string &name) OFX_EXCEPTION_SPEC;
 
-        /// the gethook virutals for  pixel scale, background colour
+        /// the gethook virtuals for  pixel scale, background colour
         virtual double getDoubleProperty(const std::string &name, int index) const OFX_EXCEPTION_SPEC;
 
         /// for pixel scale and background colour
@@ -203,7 +203,7 @@ namespace OFX {
         // 
         // Params -
         //
-        //    time              - the effect time at which changed occured
+        //    time              - the effect time at which changed occurred
         //    renderScale       - the render scale
         virtual OfxStatus drawAction(OfxTime time,
                                      const OfxPointD &renderScale
@@ -219,7 +219,7 @@ namespace OFX {
         //
         // Params  -
         //
-        //    time              - the effect time at which changed occured
+        //    time              - the effect time at which changed occurred
         //    renderScale       - the render scale
         //    penX              - the X position
         //    penY              - the Y position
@@ -240,7 +240,7 @@ namespace OFX {
         //
         // Params  -
         //
-        //    time              - the effect time at which changed occured
+        //    time              - the effect time at which changed occurred
         //    renderScale       - the render scale
         //    penX              - the X position
         //    penY              - the Y position
@@ -261,7 +261,7 @@ namespace OFX {
         //
         // Params  -
         //
-        //    time              - the effect time at which changed occured
+        //    time              - the effect time at which changed occurred
         //    renderScale       - the render scale
         //    penX              - the X position
         //    penY              - the Y position
@@ -282,7 +282,7 @@ namespace OFX {
         //
         // Params  -
         //
-        //    time              - the effect time at which changed occured
+        //    time              - the effect time at which changed occurred
         //    renderScale       - the render scale
         //    key               - the pressed key
         //    keyString         - the pressed key string
@@ -301,7 +301,7 @@ namespace OFX {
         //
         // Params  -
         //
-        //    time              - the effect time at which changed occured
+        //    time              - the effect time at which changed occurred
         //    renderScale       - the render scale
         //    key               - the pressed key
         //    keyString         - the pressed key string
@@ -320,7 +320,7 @@ namespace OFX {
         //
         // Params  -
         //
-        //    time              - the effect time at which changed occured
+        //    time              - the effect time at which changed occurred
         //    renderScale       - the render scale
         //    key               - the pressed key
         //    keyString         - the pressed key string
@@ -339,7 +339,7 @@ namespace OFX {
         // 
         // Params -
         //
-        //    time              - the effect time at which changed occured
+        //    time              - the effect time at which changed occurred
         //    renderScale       - the render scale
         virtual OfxStatus gainFocusAction(OfxTime time,
                                           const OfxPointD &renderScale
@@ -355,7 +355,7 @@ namespace OFX {
         // 
         // Params -
         //
-        //    time              - the effect time at which changed occured
+        //    time              - the effect time at which changed occurred
         //    renderScale       - the render scale
         virtual OfxStatus loseFocusAction(OfxTime  time,
                                           const OfxPointD &renderScale

--- a/HostSupport/include/ofxhParam.h
+++ b/HostSupport/include/ofxhParam.h
@@ -319,7 +319,7 @@ namespace OFX {
       public:
         IntegerInstance(Descriptor& descriptor, Param::SetInstance* instance = 0) : Instance(descriptor,instance) {}
 
-        // Deriving implementatation needs to overide these 
+        // Deriving implementation needs to override these 
         virtual OfxStatus get(int&) = 0;
         virtual OfxStatus get(OfxTime time, int&) = 0;
         virtual OfxStatus set(int) = 0;
@@ -355,7 +355,7 @@ namespace OFX {
         // callback which should set option as appropriate
         virtual void setOption(int num);
 
-        // Deriving implementatation needs to overide these 
+        // Deriving implementation needs to override these 
         virtual OfxStatus get(int&) = 0;
         virtual OfxStatus get(OfxTime time, int&) = 0;
         virtual OfxStatus set(int) = 0;
@@ -381,7 +381,7 @@ namespace OFX {
       public:
         DoubleInstance(Descriptor& descriptor, Param::SetInstance* instance = 0) : Instance(descriptor,instance) {}
 
-        // Deriving implementatation needs to overide these 
+        // Deriving implementation needs to override these 
         virtual OfxStatus get(double&) = 0;
         virtual OfxStatus get(OfxTime time, double&) = 0;
         virtual OfxStatus set(double) = 0;
@@ -412,7 +412,7 @@ namespace OFX {
       public:
         BooleanInstance(Descriptor& descriptor, Param::SetInstance* instance = 0) : Instance(descriptor,instance) {}
 
-        // Deriving implementatation needs to overide these
+        // Deriving implementation needs to override these
         virtual OfxStatus get(bool&) = 0;
         virtual OfxStatus get(OfxTime time, bool&) = 0;
         virtual OfxStatus set(bool) = 0;
@@ -435,7 +435,7 @@ namespace OFX {
       public:
         RGBAInstance(Descriptor& descriptor, Param::SetInstance* instance = 0) : Instance(descriptor,instance) {}
 
-        // Deriving implementatation needs to overide these
+        // Deriving implementation needs to override these
         virtual OfxStatus get(double&,double&,double&,double&) = 0;
         virtual OfxStatus get(OfxTime time, double&,double&,double&,double&) = 0;
         virtual OfxStatus set(double,double,double,double) = 0;
@@ -468,7 +468,7 @@ namespace OFX {
       public:
         RGBInstance(Descriptor& descriptor, Param::SetInstance* instance = 0) : Instance(descriptor,instance) {}
 
-        // Deriving implementatation needs to overide these
+        // Deriving implementation needs to override these
         virtual OfxStatus get(double&,double&,double&) = 0;
         virtual OfxStatus get(OfxTime time, double&,double&,double&) = 0;
         virtual OfxStatus set(double,double,double) = 0;
@@ -501,7 +501,7 @@ namespace OFX {
       public:
         Double2DInstance(Descriptor& descriptor, Param::SetInstance* instance = 0) : Instance(descriptor,instance) {}
 
-        // Deriving implementatation needs to overide these
+        // Deriving implementation needs to override these
         virtual OfxStatus get(double&,double&) = 0;
         virtual OfxStatus get(OfxTime time, double&,double&) = 0;
         virtual OfxStatus set(double,double) = 0;
@@ -534,7 +534,7 @@ namespace OFX {
       public:
         Integer2DInstance(Descriptor& descriptor, Param::SetInstance* instance = 0) : Instance(descriptor,instance) {}
 
-        // Deriving implementatation needs to overide these
+        // Deriving implementation needs to override these
         virtual OfxStatus get(int&,int&) = 0;
         virtual OfxStatus get(OfxTime time, int&,int&) = 0;
         virtual OfxStatus set(int,int) = 0;
@@ -567,7 +567,7 @@ namespace OFX {
       public:
         Double3DInstance(Descriptor& descriptor, Param::SetInstance* instance = 0) : Instance(descriptor,instance) {}
 
-        // Deriving implementatation needs to overide these
+        // Deriving implementation needs to override these
         virtual OfxStatus get(double&,double&,double&)  = 0;
         virtual OfxStatus get(OfxTime time, double&,double&,double&)  = 0;
         virtual OfxStatus set(double,double,double)  = 0;
@@ -678,7 +678,7 @@ namespace OFX {
       public :
         /// ctor
         ///
-        /// The propery set being passed in belongs to the owning 
+        /// The property set being passed in belongs to the owning 
         /// plugin instance.
         explicit SetInstance();
 

--- a/HostSupport/include/ofxhPluginAPICache.h
+++ b/HostSupport/include/ofxhPluginAPICache.h
@@ -57,7 +57,7 @@ namespace OFX
   {
     namespace APICache {
 
-      /// this acts as an interface for the Plugin Cache, handling api-specific cacheing
+      /// this acts as an interface for the Plugin Cache, handling api-specific caching
       class PluginAPICacheI
       {
       protected:

--- a/HostSupport/include/ofxhPluginCache.h
+++ b/HostSupport/include/ofxhPluginCache.h
@@ -58,7 +58,7 @@ namespace OFX {
     
     class Host;
 
-    // forward delcarations
+    // forward declarations
     class PluginDesc;   
     class Plugin;
     class PluginBinary;
@@ -495,7 +495,7 @@ namespace OFX {
       }
 #endif
 
-      /// specify which subdirectory of /usr/OFX or equivilant
+      /// specify which subdirectory of /usr/OFX or equivalent
       /// (as well as 'Plugins') to look in for plugins.
       void setPluginHostPath(const std::string &hostId);
 

--- a/HostSupport/include/ofxhPropertySuite.h
+++ b/HostSupport/include/ofxhPropertySuite.h
@@ -105,7 +105,7 @@ namespace OFX {
       /// type holder, for integers, used to template up int properties
       struct IntValue { 
         typedef int APIType; ///< C type of the property that is passed across the raw API
-        typedef int Type; ///< Type we actually hold and deal with the propery in everything by the raw API
+        typedef int Type; ///< Type we actually hold and deal with the property in everything by the raw API
         typedef int ReturnType; ///< type to return from a function call
         static const TypeEnum typeCode = eInt;
         static int kEmpty;
@@ -470,7 +470,7 @@ namespace OFX {
         /// specialised versions of this.
         void addNotifyHook(const std::string &name, NotifyHook *hook) const;
                 
-        /// Fetchs a pointer to a property of the given name, following the property chain if the
+        /// Fetches a pointer to a property of the given name, following the property chain if the
         /// 'followChain' arg is not false.
         Property *fetchProperty(const std::string &name, bool followChain = false) const;
 

--- a/HostSupport/include/ofxhUtilities.h
+++ b/HostSupport/include/ofxhUtilities.h
@@ -47,7 +47,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
     if (host) {                                                         \
       try {                                                             \
         (host)->message(kOfxMessageError, "",                           \
-                        "%s: Memory allocation error occured in plugin %s (%s)", \
+                        "%s: Memory allocation error occurred in plugin %s (%s)", \
                         (msg), (plugin)->pluginIdentifier, ba.what());  \
       } catch (...) {                                                   \
       }                                                                 \
@@ -57,7 +57,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
     if (host) {                                                         \
       try {                                                             \
         (host)->message(kOfxMessageError, "",                           \
-                        "%s: Exception occured in plugin %s (%s)",      \
+                        "%s: Exception occurred in plugin %s (%s)",      \
                         (msg), (plugin)->pluginIdentifier, e.what());   \
       } catch (...) {                                                   \
       }                                                                 \
@@ -67,7 +67,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
     if (host) {                                                         \
       try {                                                             \
         (host)->message(kOfxMessageError, "",                           \
-                        "%s:Exception occured in plugin %s",            \
+                        "%s:Exception occurred in plugin %s",            \
                         (msg), (plugin)->pluginIdentifier);             \
       } catch (...) {                                                   \
       }                                                                 \

--- a/HostSupport/src/ofxhClip.cpp
+++ b/HostSupport/src/ofxhClip.cpp
@@ -56,7 +56,7 @@ namespace OFX {
 
     namespace ImageEffect {
 
-      /// properties common to the desciptor and instance
+      /// properties common to the descriptor and instance
       /// the desc and set them, the instance cannot
       static const Property::PropSpec clipDescriptorStuffs[] = {
         { kOfxPropType, Property::eString, 1, true, kOfxTypeClip },
@@ -372,7 +372,7 @@ namespace OFX {
           return components;
       }
 #endif
-      // get the virutals for viewport size, pixel scale, background colour
+      // get the virtuals for viewport size, pixel scale, background colour
       void ClipInstance::getDoublePropertyN(const std::string &name, double *values, int n) const OFX_EXCEPTION_SPEC
       {
         if(n<=0) throw Property::Exception(kOfxStatErrValue);
@@ -400,7 +400,7 @@ namespace OFX {
           throw Property::Exception(kOfxStatErrValue);
       }
 
-      // get the virutals for viewport size, pixel scale, background colour
+      // get the virtuals for viewport size, pixel scale, background colour
       double ClipInstance::getDoubleProperty(const std::string &name, int n) const OFX_EXCEPTION_SPEC
       {
         if(name==kOfxImagePropPixelAspectRatio){
@@ -431,7 +431,7 @@ namespace OFX {
           throw Property::Exception(kOfxStatErrValue);
       }
 
-      // get the virutals for viewport size, pixel scale, background colour
+      // get the virtuals for viewport size, pixel scale, background colour
       int ClipInstance::getIntProperty(const std::string &name, int n) const OFX_EXCEPTION_SPEC
       {
         if(name==kOfxImageClipPropConnected){
@@ -461,7 +461,7 @@ namespace OFX {
         }
       }
 
-      // get the virutals for viewport size, pixel scale, background colour
+      // get the virtuals for viewport size, pixel scale, background colour
       void ClipInstance::getIntPropertyN(const std::string &name, int *values, int n) const OFX_EXCEPTION_SPEC
       {
         if(n<=0) throw Property::Exception(kOfxStatErrValue);
@@ -482,7 +482,7 @@ namespace OFX {
         }
       }
 
-      // get the virutals for viewport size, pixel scale, background colour
+      // get the virtuals for viewport size, pixel scale, background colour
       const std::string &ClipInstance::getStringProperty(const std::string &name, int n) const OFX_EXCEPTION_SPEC
       {
 #ifdef OFX_EXTENSIONS_NUKE
@@ -650,7 +650,7 @@ namespace OFX {
             return rgb;
         }
 
-        /// wierd, must be some custom bit , if only one, choose that, otherwise no idea
+        /// weird, must be some custom bit , if only one, choose that, otherwise no idea
         /// how to map, you need to derive to do so.
         const std::vector<std::string> &supportedComps = getSupportedComponents();
         if(supportedComps.size() == 1)

--- a/HostSupport/src/ofxhHost.cpp
+++ b/HostSupport/src/ofxhHost.cpp
@@ -112,7 +112,7 @@ namespace OFX {
       _host.host = _properties.getHandle();
       _host.fetchSuite = OFX::Host::fetchSuite;
 
-      // record the host descriptor in the propert set
+      // record the host descriptor in the property set
       _properties.setPointerProperty(kOfxHostSupportHostPointer,this);
     }
 

--- a/HostSupport/src/ofxhImageEffect.cpp
+++ b/HostSupport/src/ofxhImageEffect.cpp
@@ -750,7 +750,7 @@ namespace OFX {
         throw Property::Exception(kOfxStatErrMissingHostFeature);
       }
 
-      // get the virutals for viewport size, pixel scale, background colour
+      // get the virtuals for viewport size, pixel scale, background colour
       double Instance::getDoubleProperty(const std::string &name, int index) const OFX_EXCEPTION_SPEC
       {
         if(name==kOfxImageEffectPropProjectSize){
@@ -858,7 +858,7 @@ namespace OFX {
 #endif
 
       Instance::~Instance(){
-        // destroy the instance, only if succesfully created
+        // destroy the instance, only if successfully created
         if (_created) {
 #         ifdef OFX_DEBUG_ACTIONS
           std::cout << "OFX WARNING: OFX::Host::ImageEffect::Instance::destroyInstanceAction() was not called before the OFX::Host::ImageEffect::Instance destructor."<<std::endl;
@@ -913,7 +913,7 @@ namespace OFX {
         return 0; 
       }
 
-      // return an memory::instance calls makeMemoryInstance that can be overriden
+      // return an memory::instance calls makeMemoryInstance that can be overridden
       Memory::Instance* Instance::imageMemoryAlloc(size_t nBytes){
         Memory::Instance* instance = newMemoryInstance(nBytes);
         if(instance)
@@ -984,7 +984,7 @@ namespace OFX {
       // create an image effect instance
       OfxStatus Instance::createInstanceAction() 
       {
-        /// we need to init the clips before we call create instance incase
+        /// we need to init the clips before we call create instance in case
         /// they try and fetch something in create instance, which they are allowed
         setDefaultClipPreferences();
 
@@ -1006,7 +1006,7 @@ namespace OFX {
         return st;
       }
 
-      // destroy the instance, only if succesfully created
+      // destroy the instance, only if successfully created
       OfxStatus Instance::destroyInstanceAction()
       {
         OfxStatus st = kOfxStatFailed;
@@ -1915,7 +1915,7 @@ namespace OFX {
         // kOfxImageEffectActionGetRegionsOfInterest. For example, if an input clip is not needed, it can
         // set the roi to an empty region on that input. On it can set the roi on each input to the
         // renderwindow instead of the input region of definition.
-        // The only difference between effects that support tiles and thos that don't is the defaut
+        // The only difference between effects that support tiles and those that don't is the default
         // region set on each input:
         // - for effects that support tiles, it is the renderwindow
         // - for effect that don't, it is the region of definition of the input clip
@@ -2337,7 +2337,7 @@ namespace OFX {
               s.readonly = false;
               s.defaultValue = "";
               outArgs.createProperty(s);
-              /// intialise it to the current frame
+              /// initialise it to the current frame
               outArgs.setDoubleProperty(name, time, 0);
               outArgs.setDoubleProperty(name, time, 1);
             }
@@ -2678,7 +2678,7 @@ namespace OFX {
       }
 
       /// Initialise the clip preferences arguments, override this to do
-      /// stuff with wierd components etc...
+      /// stuff with weird components etc...
       void Instance::setupClipPreferencesArgs(Property::Set &outArgs)
       {
         /// reset all the clip prefs stuff to their defaults
@@ -4222,7 +4222,7 @@ namespace OFX {
       /// ctor
       Host::Host() 
       {
-        /// add the properties for an image effect host, derived classs to set most of them
+        /// add the properties for an image effect host, derived classes to set most of them
         _properties.addProperties(hostStuffs);
       }
 
@@ -4246,7 +4246,7 @@ namespace OFX {
         return 0;
       }
 
-      // return an memory::instance calls makeMemoryInstance that can be overriden
+      // return an memory::instance calls makeMemoryInstance that can be overridden
       Memory::Instance* Host::imageMemoryAlloc(size_t nBytes){
         Memory::Instance* instance = newMemoryInstance(nBytes);
         if(instance)

--- a/HostSupport/src/ofxhInteract.cpp
+++ b/HostSupport/src/ofxhInteract.cpp
@@ -188,7 +188,7 @@ namespace OFX {
 
       Instance::~Instance()
       {
-        /// call it directly incase CI failed and we should always tidy up after create instance
+        /// call it directly in case CI failed and we should always tidy up after create instance
         callEntry(kOfxActionDestroyInstance,  NULL);
       }
 

--- a/HostSupport/src/ofxhParam.cpp
+++ b/HostSupport/src/ofxhParam.cpp
@@ -391,7 +391,7 @@ namespace OFX {
   
         if (isDoubleParam(type) || isIntParam(type) || isColourParam(type)
 #         ifdef OFX_SUPPORTS_PARAMETRIC
-            || type == kOfxParamTypeParametric // although not explicitely stated in the OFX 1.4 spec, it seems logical
+            || type == kOfxParamTypeParametric // although not explicitly stated in the OFX 1.4 spec, it seems logical
 #         endif
             ) {
           addNumericParamProps(type, propType, propDim);

--- a/HostSupport/src/ofxhPropertySuite.cpp
+++ b/HostSupport/src/ofxhPropertySuite.cpp
@@ -380,7 +380,7 @@ namespace OFX {
         }
       }
 
-      // explicit instanciations (required by ofxhPluginAPICache.cpp)
+      // explicit instantiations (required by ofxhPluginAPICache.cpp)
       template class PropertyTemplate<IntValue>;
       template class PropertyTemplate<DoubleValue>;
       template class PropertyTemplate<PointerValue>;

--- a/Support/Library/ofxsHWNDInteract.cpp
+++ b/Support/Library/ofxsHWNDInteract.cpp
@@ -93,7 +93,7 @@ namespace OFX {
     throwSuiteStatusException(stat);
     _interactProperties.propSetHandle(propHandle);
 
-    // set othe instance data on the property handle to point to this interact
+    // set other instance data on the property handle to point to this interact
     _interactProperties.propSetPointer(kOfxPropInstanceData, (void *)this);
 
     // get the effect handle from this handle        

--- a/Support/Library/ofxsImageEffect.cpp
+++ b/Support/Library/ofxsImageEffect.cpp
@@ -107,7 +107,7 @@ static const int charXMLCompatiblity[] =
 // Check the effect descriptor for potentially bad XML in the OFX Plugin cache.
 //
 // The function that wrote string properties to the OFX plugin cache used to
-// escape only que quote (") character. As a result, if one of the string
+// escape only the quote (") character. As a result, if one of the string
 // properties in the Image Effect descriptor contains special characters,
 // the host may be unable to read the plugin cache, giving an "xml error 4"
 // (error 4 is XML_ERROR_INVALID_TOKEN).
@@ -603,7 +603,7 @@ namespace OFX {
 
     const std::size_t planeNameStartIdx = foundPlane + foundPlaneLen;
 
-    // Find the optionnal plane label
+    // Find the optional plane label
     // If planeLabelStartIdx = 0, there's no plane label.
     std::size_t planeLabelStartIdx = 0;
 
@@ -616,7 +616,7 @@ namespace OFX {
 
 
 
-    // Find the optionnal channels label
+    // Find the optional channels label
     // If channelsLabelStartIdx = 0, there's no channels label.
     std::size_t channelsLabelStartIdx = 0;
 
@@ -2976,7 +2976,7 @@ namespace OFX {
         return rgb;
     }
 
-    /// wierd, must be some custom bit , if only one, choose that, otherwise no idea
+    /// weird, must be some custom bit , if only one, choose that, otherwise no idea
     /// how to map, you need to derive to do so.
     return none;
   }
@@ -4829,7 +4829,7 @@ namespace OFX {
       if(v && transformClip) {
         outArgs.propSetString(kOfxPropName, transformClip->name());
         outArgs.propSetDoubleN(kFnOfxPropMatrix2D, transformMatrix, 9);
-        return true; // the transfrom and clip name were set and can be used to modify the named image appropriately
+        return true; // the transform and clip name were set and can be used to modify the named image appropriately
       }
       return false; // don't attempt to use the transform matrix, but render the image as per normal
     }
@@ -4886,7 +4886,7 @@ namespace OFX {
             outArgs.propSetInt(kOfxPropInverseDistortionFunctionDataSize, distortionFunctionDataSize);
             outArgs.propSetPointer(kOfxPropInverseDistortionDataFreeFunction, (void*)freeDataFunction);
           }
-          return true; // the transfrom and clip name were set and can be used to modify the named image appropriately
+          return true; // the transform and clip name were set and can be used to modify the named image appropriately
         }
       } else {
         // effect can not distort, maybe it can transform?
@@ -4927,7 +4927,7 @@ namespace OFX {
           //transformMatrix[8] *= 1.;
 
           outArgs.propSetDoubleN(kOfxPropMatrix3x3, transformMatrix, 9);
-          return true; // the transfrom and clip name were set and can be used to modify the named image appropriately
+          return true; // the transform and clip name were set and can be used to modify the named image appropriately
         }
       }
       return false; // don't attempt to use the distortion function, but render the image as per normal

--- a/Support/Library/ofxsInteract.cpp
+++ b/Support/Library/ofxsInteract.cpp
@@ -98,7 +98,7 @@ namespace OFX {
     throwSuiteStatusException(stat);
     _interactProperties.propSetHandle(propHandle);
 
-    // set othe instance data on the property handle to point to this interact
+    // set other instance data on the property handle to point to this interact
     _interactProperties.propSetPointer(kOfxPropInstanceData, (void *)this);
 
     // get the effect handle from this handle        
@@ -158,7 +158,7 @@ namespace OFX {
   }
 
 #ifdef OFX_EXTENSIONS_NATRON
-  /** @brief Sets wether the interact uses an additional colour picking value in the inArgs of its actions. */
+  /** @brief Sets whether the interact uses an additional colour picking value in the inArgs of its actions. */
   void
     Interact::setColourPicking(bool useColourPicking)
   {
@@ -420,7 +420,7 @@ namespace OFX {
   }
 
 #ifdef OFX_EXTENSIONS_NATRON
-  /** @brief Sets wether the interact uses an additional colour picking value in the inArgs of its actions. */
+  /** @brief Sets whether the interact uses an additional colour picking value in the inArgs of its actions. */
   void InteractDescriptor::setColourPicking(bool useColourPicking)
   {
     _props->propSetInt(kNatronOfxInteractColourPicking, (int)useColourPicking, 0, false);

--- a/Support/Library/ofxsLog.cpp
+++ b/Support/Library/ofxsLog.cpp
@@ -79,7 +79,7 @@ namespace OFX {
       gLogFileName = value;
     }
 
-    /** @brief Opens the log file, returns whether this was sucessful or not. */
+    /** @brief Opens the log file, returns whether this was successful or not. */
     bool open(void)
     {
 #ifdef DEBUG

--- a/Support/Library/ofxsParams.cpp
+++ b/Support/Library/ofxsParams.cpp
@@ -266,9 +266,9 @@ namespace OFX {
     , _paramType(type)
     , _paramProps(props)
   {
-    // validate the properities on this descriptor
+    // validate the properties on this descriptor
     if(type != eDummyParam)
-      OFX::Validation::validateParameterProperties(type, props, true); 
+      OFX::Validation::validateParameterProperties(type, props, true);
   }
 
   ParamDescriptor::~ParamDescriptor()
@@ -346,10 +346,10 @@ namespace OFX {
     }
   }
 #endif
-    
+
 #ifdef OFX_EXTENSIONS_NATRON
     /** @brief When set to true, the parameter is specific to an effect instance of the plug-in and should have a
-     unique representation for each instance. See descripton of kNatronOfxImageEffectContextTracker for more details
+     unique representation for each instance. See description of kNatronOfxImageEffectContextTracker for more details
      on multiple instances and difference between shared and specific parameters.*/
   void
     ParamDescriptor::setInstanceSpecific(bool isSpecific)
@@ -1998,14 +1998,14 @@ namespace OFX {
     return _paramProps.propGetInt(kOfxParamPropPersistent) != 0;
   }
 
-  /** @brief Get's whether the value of the param is significant (ie: affects the rendered image) */
+  /** @brief Gets whether the value of the param is significant (ie: affects the rendered image) */
   bool 
     ValueParam::getEvaluateOnChange(void) const
   {
     return _paramProps.propGetInt(kOfxParamPropEvaluateOnChange) != 0;
   }
 
-  /** @brief Get's whether the value of the param is significant (ie: affects the rendered image) */
+  /** @brief Gets whether the value of the param is significant (ie: affects the rendered image) */
   CacheInvalidationEnum 
     ValueParam::getCacheInvalidation(void) const
   {
@@ -3669,7 +3669,7 @@ namespace OFX {
   /** @brief set the hard min/max range, default is -DBL_MAX, DBL_MAX */
   void ParametricParam::setDimensionRange(int curveIndex, double min, double max)
   {
-    // don't throw: the OFX 1.4 spec is not clear wether these properties exist
+    // don't throw: the OFX 1.4 spec is not clear whether these properties exist
     _paramProps.propSetDouble(kOfxParamPropMin, min, curveIndex, false);
     _paramProps.propSetDouble(kOfxParamPropMax, max, curveIndex, false);
   }
@@ -3677,7 +3677,7 @@ namespace OFX {
   /** @brief set the display min and max, default is to be the same as the range param */
   void ParametricParam::setDimensionDisplayRange(int curveIndex, double min, double max)
   {
-    // don't throw: the OFX 1.4 spec is not clear wether these properties exist
+    // don't throw: the OFX 1.4 spec is not clear whether these properties exist
     _paramProps.propSetDouble(kOfxParamPropDisplayMin, min, curveIndex, false);
     _paramProps.propSetDouble(kOfxParamPropDisplayMax, max, curveIndex, false);
   }

--- a/Support/Library/ofxsProperty.cpp
+++ b/Support/Library/ofxsProperty.cpp
@@ -57,7 +57,7 @@ namespace OFX {
       break;
 
     case kOfxStatErrUnknown :
-    case kOfxStatErrUnsupported : // unsupported implies unknow here
+    case kOfxStatErrUnsupported : // unsupported implies unknown here
       if(OFX::PropertySet::getThrowOnUnsupportedProperties()) // are we suppressing this?
         throw OFX::Exception::PropertyUnknownToHost(propName.c_str());
       break;
@@ -87,7 +87,7 @@ namespace OFX {
   /** @brief Virtual destructor */
   PropertySet::~PropertySet() {}
 
-  /** @brief, returns wether the given property exists in this property set */
+  /** @brief, returns whether the given property exists in this property set */
   bool PropertySet::propExists(const char* property, bool throwOnFailure) const OFX_THROW3(std::bad_alloc,
     OFX::Exception::PropertyValueIllegalToHost,
     OFX::Exception::Suite)
@@ -132,7 +132,7 @@ namespace OFX {
   {
     assert(_propHandle != 0);
     OfxStatus stat = gPropSuite->propReset(_propHandle, property);
-    Log::error(stat != kOfxStatOK, "Failed on reseting property %s to its defaults, host returned status %s.", property, mapStatusToString(stat));
+    Log::error(stat != kOfxStatOK, "Failed on resetting property %s to its defaults, host returned status %s.", property, mapStatusToString(stat));
     throwPropertyException(stat, property); 
 
     if(_gPropLogging > 0) Log::print("Reset property %s.",  property);

--- a/Support/Library/ofxsPropertyValidation.cpp
+++ b/Support/Library/ofxsPropertyValidation.cpp
@@ -329,7 +329,7 @@ namespace OFX {
       PropertyDescription(kOfxImageEffectPropSupportedComponents,        OFX::eString, -1, eDescFinished),
       PropertyDescription(kOfxImageEffectPropSupportedContexts,          OFX::eString, -1, eDescFinished),
 
-      // multi dimensional int properities
+      // multi dimensional int properties
       PropertyDescription(kOfxParamHostPropPageRowColumnCount,           OFX::eInt, 2, eDescFinished),
     };
 

--- a/Support/OSXStaticLoader/pluginLoader.cpp
+++ b/Support/OSXStaticLoader/pluginLoader.cpp
@@ -43,7 +43,7 @@ main(int argc, char *argv[])
       int nP =  nPluginsFunc();
 
 
-      printf("Sucessfully loaded '%s', containing %d %s\n", argv[1], nP, (nP == 1 ? "plugin" : "plugins"));    
+      printf("Successfully loaded '%s', containing %d %s\n", argv[1], nP, (nP == 1 ? "plugin" : "plugins"));    
 
       for(int i = 0; i < nP; i++) {
 	// get a plugin

--- a/Support/Plugins/Basic/basic.cpp
+++ b/Support/Plugins/Basic/basic.cpp
@@ -471,7 +471,7 @@ BasicPlugin:: isIdentity(const OFX::IsIdentityArguments &args, OFX::Clip * &iden
 void
 BasicPlugin::setEnabledness(void)
 {
-  // the componet enabledness depends on the clip being RGBA and the param being true
+  // the component enabledness depends on the clip being RGBA and the param being true
   bool v = componentScalesEnabled_->getValue() && srcClip_->getPixelComponents() == OFX::ePixelComponentRGBA;
 
   // enable them
@@ -608,7 +608,7 @@ BasicInteract::penDown(const OFX::PenArgs &args)
     // move our position
     _position = args.penPosition;
 
-    // and request a redraw just incase
+    // and request a redraw just in case
     _effect->redrawOverlays();
   }
 

--- a/Support/Plugins/Retimer/retimer.cpp
+++ b/Support/Plugins/Retimer/retimer.cpp
@@ -307,7 +307,7 @@ mRegisterPluginFactoryInstance(p)
 
 void RetimerExamplePluginFactory::load()
 {
-  // we can't be used on hosts that don't perfrom temporal clip access
+  // we can't be used on hosts that don't perform temporal clip access
   if(!gHostDescription.temporalClipAccess) {
     throw OFX::Exception::HostInadequate("Need random temporal image access to work");
   }

--- a/Support/Plugins/Transition/crossFade.cpp
+++ b/Support/Plugins/Transition/crossFade.cpp
@@ -223,7 +223,7 @@ CrossFadePlugin::isIdentity(const OFX::IsIdentityArguments &args, OFX::Clip * &i
     return true;
   }
 
-  // nope, identity we isnt
+  // nope, identity we isn't
   return false;
 }
 

--- a/Support/README
+++ b/Support/README
@@ -56,7 +56,7 @@ Release Notes
 	   Still to be done,
 	   	 decent set of exceptions and exception specifiers on each function,
 		 skin the parameter custom interact,
-		 parameter integration and differentiation functions needed on 2D and 3D doubles and the colour classses,
+		 parameter integration and differentiation functions needed on 2D and 3D doubles and the colour classes,
 		 parameters should return their values in a struct, as well as by a reference arg (some do already),
 		 write examples showing custom param and param animation,
 		 write an example showing use of external resource files,
@@ -66,7 +66,7 @@ Release Notes
 	   
 	   Implemented most of the basic classes, need to do more work on clip instances and image effect instances.     
            Library builds fine on OSX 10.3, not fully tested yet.
-           No where near finsihed yet,
+           No where near finished yet,
            	   Need to finish off the actions.
                    Need to do a cleaner set of exception classes. 
                    Need to test somewhat more (hey they do compile though!).

--- a/Support/include/ofxsCore.h
+++ b/Support/include/ofxsCore.h
@@ -216,7 +216,7 @@ namespace OFX {
   /** @brief Enumerates the reasons a plug-in instance may have had one of its values changed */
   enum InstanceChangeReason {
     eChangeUserEdit,    /**< @brief A user actively editted something in the plugin, eg: changed the value of an integer param on an interface */
-    eChangePluginEdit,  /**< @brief The plugin's own code changed something in the instance, eg: a callback on on param settting the value of another */
+    eChangePluginEdit,  /**< @brief The plugin's own code changed something in the instance, eg: a callback on on param setting the value of another */
     eChangeTime         /**< @brief The current value of a parameter has changed because the param animates and the current time has changed */
   };
 
@@ -417,7 +417,7 @@ namespace OFX {
       OFX::Exception::PropertyValueIllegalToHost,
       OFX::Exception::Suite);
 
-    // values is before count to avoid an easy confusion with propSetInt, whet the pointer to values would be cast to bool
+    // values is before count to avoid an easy confusion with propSetInt, when the pointer to values would be cast to bool
     void propSetIntN(const char* property, const int *values, int count, bool throwOnFailure = true) OFX_THROW4(std::bad_alloc,
       OFX::Exception::PropertyUnknownToHost,
       OFX::Exception::PropertyValueIllegalToHost,
@@ -519,7 +519,7 @@ namespace OFX {
       OFX::Exception::PropertyValueIllegalToHost,
       OFX::Exception::Suite);
 
-    // values is before count to avoid an easy confusion with propGetDouble, whet the pointer to values would be cast to bool
+    // values is before count to avoid an easy confusion with propGetDouble, when the pointer to values would be cast to bool
     void propGetDoubleN(const char* property, double* values, int count, bool throwOnFailure = true) const OFX_THROW4(std::bad_alloc,
       OFX::Exception::PropertyUnknownToHost,
       OFX::Exception::PropertyValueIllegalToHost,

--- a/Support/include/ofxsHWNDInteract.h
+++ b/Support/include/ofxsHWNDInteract.h
@@ -61,7 +61,7 @@ namespace OFX {
   /** @brief forward declaration */
   class ImageEffect;
 
-  /// all image effect interacts have these argumens
+  /// all image effect interacts have these arguments
   struct HWNDInteractArgs {
     /// ctor
     HWNDInteractArgs(const PropertySet &props);

--- a/Support/include/ofxsImageEffect.h
+++ b/Support/include/ofxsImageEffect.h
@@ -2081,8 +2081,8 @@ namespace OFX {
      This let a chance to the host to concatenate distortion effects together filter only once.
      @param distortionFunctionDataSizeHintInBytes This should indicate the size in bytes of the data held by distortionFunctionData.
      Since distortionFunctionData may contain the result of heavy computations (such as a STMap), the host will attempt to cache these data.
-     However the void* does not indicate much to the host as to "how heavy" these datas are in its cache, so this parameter should hint
-     the host of the size of these datas in bytes.
+     However the void* does not indicate much to the host as to "how heavy" this data is in its cache, so this parameter should hint
+     the host of the size of this data in bytes.
 
      If the effect distortion can be represented as a 3x3 matrix, then leave the function pointer to NULL and fill the transform matrix.
      This will enable the host to better concatenate the distortion in such cases where 3x3 matrices can be multiplied together instead

--- a/Support/include/ofxsInteract.h
+++ b/Support/include/ofxsInteract.h
@@ -58,7 +58,7 @@ namespace OFX {
   /** @brief forward declaration */
   class ImageEffect;
 
-  /// all image effect interacts have these argumens
+  /// all image effect interacts have these arguments
   struct InteractArgs {
     /// ctor
     InteractArgs(const PropertySet &props);
@@ -232,7 +232,7 @@ namespace OFX {
     void swapBuffers(void) const;
 
 #ifdef OFX_EXTENSIONS_NATRON
-    /** @brief Sets wether the interact uses an additional colour picking value in the inArgs of its actions. */
+    /** @brief Sets whether the interact uses an additional colour picking value in the inArgs of its actions. */
     void setColourPicking(bool useColourPicking);
 #endif
 
@@ -468,7 +468,7 @@ namespace OFX {
     bool getHasAlpha() const;
     int getBitDepth() const;
 #ifdef OFX_EXTENSIONS_NATRON
-    /** @brief Sets wether the interact uses an additional colour picking value in the inArgs of its actions. */
+    /** @brief Sets whether the interact uses an additional colour picking value in the inArgs of its actions. */
     void setColourPicking(bool useColourPicking);
 #endif
     virtual OfxPluginEntryPoint* getMainEntry() = 0;

--- a/Support/include/ofxsLog.h
+++ b/Support/include/ofxsLog.h
@@ -55,7 +55,7 @@ namespace OFX {
     /** @brief Sets the name of the log file. */
     void setFileName(const std::string &value);
 
-    /** @brief Opens the log file, returns whether this was sucessful or not. */
+    /** @brief Opens the log file, returns whether this was successful or not. */
     bool open(void);
 
     /** @brief Closes the log file. */

--- a/Support/include/ofxsMemory.h
+++ b/Support/include/ofxsMemory.h
@@ -55,12 +55,12 @@ namespace OFX {
     /** @brief Allocate memory.
 
     \arg \e nBytes        - the number of bytes to allocate
-    \arg \e handle	      - effect instance to assosciate with this memory allocation, or NULL
+    \arg \e handle	      - effect instance to associate with this memory allocation, or NULL
 
     This function has the host allocate memory using it's own memory resources
     and returns that to the plugin. This memory is distinct to any image memory allocation.
 
-    Suceeds or throws std::bad_alloc
+    Succeeds or throws std::bad_alloc
     */   
     void *allocate(size_t nBytes,
       ImageEffect *handle = 0) OFX_THROW(std::bad_alloc);

--- a/Support/include/ofxsParam.h
+++ b/Support/include/ofxsParam.h
@@ -168,8 +168,8 @@ namespace OFX {
     /** @brief Enumerates the differing types of double params */
     enum DoubleTypeEnum {
         eDoubleTypePlain, //!< parameter has no special interpretation
-        eDoubleTypeAngle, //!< parameter is to be interpretted as an angle
-        eDoubleTypeScale, //!< parameter is to be interpretted as a scale factor
+        eDoubleTypeAngle, //!< parameter is to be interpreted as an angle
+        eDoubleTypeScale, //!< parameter is to be interpreted as a scale factor
         eDoubleTypeTime, //!< parameter represents a time value (1D only)
         eDoubleTypeAbsoluteTime, //!< parameter represents an absolute time value (1D only),
         eDoubleTypeX, //!< a size in the X dimension dimension (1D only), new for 1.2
@@ -325,7 +325,7 @@ namespace OFX {
         
 #ifdef OFX_EXTENSIONS_NATRON
         /** @brief When set to true, the parameter is specific to an effect instance of the plug-in and should have a
-         unique representation for each instance. See descripton of kNatronOfxImageEffectContextTracker for more details
+         unique representation for each instance. See description of kNatronOfxImageEffectContextTracker for more details
          on multiple instances and difference between shared and specific parameters.*/
         void setInstanceSpecific(bool isSpecific);
 
@@ -1302,10 +1302,10 @@ namespace OFX {
         /** @brief is the param animating */
         bool getIsPersistent(void) const;
     
-        /** @brief Get's whether the value of the param is significant (ie: affects the rendered image) */
+        /** @brief Gets whether the value of the param is significant (ie: affects the rendered image) */
         bool getEvaluateOnChange(void) const;
 
-        /** @brief Get's whether the value of the param is significant (ie: affects the rendered image) */
+        /** @brief Gets whether the value of the param is significant (ie: affects the rendered image) */
         CacheInvalidationEnum getCacheInvalidation(void) const;
 
         /** @brief if the param is animating, the number of keys in it, otherwise 0 */

--- a/Support/include/osxDeploy.sh
+++ b/Support/include/osxDeploy.sh
@@ -113,7 +113,7 @@ if otool -L "$binary"  | grep -F libMagick > /dev/null; then
     IMAGEMAGICKMAJ=${IMAGEMAGICKVER%.*.*}
     IMAGEMAGICKLIB=$(pkg-config --variable=libdir ImageMagick)
     IMAGEMAGICKSHARE=$(pkg-config --variable=prefix ImageMagick)/share
-    # if I get this right, sed substitutes in the exe the occurences of IMAGEMAGICKVER
+    # if I get this right, sed substitutes in the exe the occurrences of IMAGEMAGICKVER
     # into the actual value retrieved from the package.
     # We don't need this because we use MAGICKCORE_PACKAGE_VERSION declared in the <magick/magick-config.h>
     # sed -e "s,IMAGEMAGICKVER,$IMAGEMAGICKVER,g" -i "" $pkgbin/DisparityKillerM

--- a/include/nuke/camera.h
+++ b/include/nuke/camera.h
@@ -128,7 +128,7 @@ This has only one dimension.
 
 /** @brief Name of the camera position parameter 
 
-This represents a homogenous 4x4 transform matrix
+This represents a homogeneous 4x4 transform matrix
 that places the camera in 3D space. As such it has 16 values.
 */
 #define kNukeOfxCameraParamPositionMatrix "position_matrix"
@@ -153,7 +153,7 @@ Instance property sets have all the descriptor properties (as read only) and the
 typedef struct NukeOfxCameraSuiteV1 {
   /** @brief Define a camera input to an effect.
 
-   \arg pluginHandle - the decriptor handle passed into the 'describeInContext' action
+   \arg pluginHandle - the descriptor handle passed into the 'describeInContext' action
    \arg name - unique name of the camera to define
    \arg propertySet - a property handle for the camera descriptor will be returned here
 
@@ -191,7 +191,7 @@ typedef struct NukeOfxCameraSuiteV1 {
   \arg returnSize   - the number of doubles at the baseReturnAddress
 
   @returns
-  - ::kOfxStatOK         - if the parameter was fetched succesfully
+  - ::kOfxStatOK         - if the parameter was fetched successfully
   - ::kOfxStatFailed     - if the camera was not connected
   - ::kOfxStatErrUnknown - if the named parameter could not be found
   */

--- a/include/nuke/fnOfxExtensions.h
+++ b/include/nuke/fnOfxExtensions.h
@@ -35,7 +35,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 /*******************************************************************************
  * I don't  like the confusion between 'components' and 'planes', but there
  * was no real way around it. The general idea is that 'component' strings 
- * are useable in the places where the standard component strings are in OFX.
+ * are usable in the places where the standard component strings are in OFX.
  * eg: kOfxImageComponentRGBA. These are basically used to indicate the
  * kind of an image.
  *
@@ -122,7 +122,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  all planes will be transformed with minimalist changes to the plug-in code. Note that with this value the plug-in must NOT have
  flagged kFnOfxImageEffectPropMultiPlanar to true.
 
-The plugin must have flagged kFnOfxImageEffectPropMultiPlanar as true, if so tghe 
+The plugin must have flagged kFnOfxImageEffectPropMultiPlanar as true, if so then
 */
 #define kFnOfxImageEffectPropPassThroughComponents "uk.co.thefoundry.OfxImageEffectPropPassThroughComponents"
 
@@ -130,7 +130,7 @@ The plugin must have flagged kFnOfxImageEffectPropMultiPlanar as true, if so tgh
 
    - Type - string X N
    - Property Set - image effect clip instance (read only)
-   - Default - all the planes specifed as supported on the given clip that exist on the clip
+   - Default - all the planes specified as supported on the given clip that exist on the clip
    - Valid Values - one or more of the following...
         - kFnOfxImagePlaneColour
         - kFnOfxImagePlaneBackwardMotionVector
@@ -143,7 +143,7 @@ The plugin must have flagged kFnOfxImageEffectPropMultiPlanar as true, if so tgh
 #define kFnOfxImageEffectPropComponentsPresent "uk.co.thefoundry.OfxImageEffectClipPropPlanesPresent"
 
 /** @brief Property indicating whether the planes listed for the output clip in the kFnOfxImageEffectActionGetClipComponents
- action should preferably be all rendered in a single render call rather than being separatly rendered.
+ action should preferably be all rendered in a single render call rather than being separately rendered.
  For example, an motion estimation effect may have in output both the backward and forward warp available as a result of a render call
  which would be more efficient to produce than just call the render action twice.
 
@@ -276,7 +276,7 @@ This property includes pass-throughs.
    - Property Set - image effect descriptor passed to kOfxActionDescribe (read/write)
    - Default - 0
    - Valid Values
-      - 0 - plugin will produce different output images depenedent on the view being rendered
+      - 0 - plugin will produce different output images dependent on the view being rendered
       - 1 - plugin will produced exactly the same image for all output views only on the rendered planes, pass through are view variant
       - 2 - plugin will produced exactly the same image for all output views for all planes (even pass through)
 */
@@ -478,7 +478,7 @@ This is a property on the descriptor.
           - The End Sequence Render Action
        - the RoD and RoI of the effect are implicitly determined by the transform returned
          by this action,
-       - the effect only needs a single image frome the clip named in the out args of this action,
+       - the effect only needs a single image from the clip named in the out args of this action,
        - for view aware effects, it would have transformed the image from the view as passed into the action,
        - the effect instance must have set kFnOfxImageEffectCanTransform to 1.
   
@@ -503,14 +503,14 @@ This is a property on the descriptor.
 
 @returns
 - ::kOfxStatDefault - don't attempt to use the transform matrix, but render the image as per normal,
-- ::kOfxStatOK - the transfrom and clip name were set and can be used to modify the named image appropriately,
+- ::kOfxStatOK - the transform and clip name were set and can be used to modify the named image appropriately,
                                                     
 */
 
 #define kFnOfxImageEffectActionGetTransform "uk.co.thefoundry.FnOfxImageEffectActionGetTransform"
 
 /** @brief Property that represents a 2D matrix
-this was originally a 4 by 4 matrix but as Phil said, we cant guess the depth z therefore we can't produce a correct 3D matrix, the host has to do it
+this was originally a 4 by 4 matrix but as Phil said, we can't guess the depth z therefore we can't produce a correct 3D matrix, the host has to do it
 
 - Type - double X 9
 - Property Set - varies, but on the out args of kFnOfxImageEffectActionGetTransform, or on an image instance (read only)

--- a/include/nuke/fnPublicOfxExtensions.h
+++ b/include/nuke/fnPublicOfxExtensions.h
@@ -45,7 +45,7 @@
     - Default - 0
     - Valid Values - 0,1 or 2
         0 - for a new line after the parameter
-        1 - for a seperator between this parameter and the one to follow
+        1 - for a separator between this parameter and the one to follow
         2 - for no new line, continue the next parameter on the same horizontal level
 
    This is a property on parameters of type ::kOfxParamPropLayoutHint, and tells the group whether it should be open or closed by default.

--- a/include/ofx.doxy
+++ b/include/ofx.doxy
@@ -182,7 +182,7 @@ SHOW_INCLUDE_FILES     = YES
 # will interpret the first line (until the first dot) of a JavaDoc-style
 # comment as the brief description. If set to NO, the JavaDoc
 # comments will behave just like the Qt-style comments (thus requiring an
-# explict @brief command for a brief description.
+# explicit @brief command for a brief description.
 
 JAVADOC_AUTOBRIEF      = NO
 
@@ -711,7 +711,7 @@ COMPACT_RTF            = NO
 RTF_HYPERLINKS         = NO
 
 # Load stylesheet definitions from file. Syntax is similar to doxygen's
-# config file, i.e. a series of assigments. You only have to provide
+# config file, i.e. a series of assignments. You only have to provide
 # replacements, missing definitions are set to their default value.
 
 RTF_STYLESHEET_FILE    =
@@ -938,7 +938,7 @@ PERL_PATH              = /usr/bin/perl
 # If the CLASS_DIAGRAMS tag is set to YES (the default) Doxygen will
 # generate a inheritance diagram (in HTML, RTF and LaTeX) for classes with base or
 # super classes. Setting the tag to NO turns the diagrams off. Note that this
-# option is superceded by the HAVE_DOT option below. This is only a fallback. It is
+# option is superseded by the HAVE_DOT option below. This is only a fallback. It is
 # recommended to install and use dot, since it yields more powerful graphs.
 
 CLASS_DIAGRAMS         = YES
@@ -971,7 +971,7 @@ CLASS_GRAPH            = YES
 COLLABORATION_GRAPH    = YES
 
 # If the UML_LOOK tag is set to YES doxygen will generate inheritance and
-# collaboration diagrams in a style similiar to the OMG's Unified Modeling
+# collaboration diagrams in a style similar to the OMG's Unified Modeling
 # Language.
 
 UML_LOOK               = NO

--- a/include/ofx.dtd
+++ b/include/ofx.dtd
@@ -1,7 +1,7 @@
 <!--
 Software License :
 
-Copyright (c) 2004, The Open Effects Assocation Ltd. All rights reserved.
+Copyright (c) 2004, The Open Effects Association Ltd. All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:
@@ -34,7 +34,7 @@ Author Bruno Nicoletti
 
 Each ofx binary may have a single xml file associated with it that is contains resource overrides for various properties of the plugin. This file is the DTD for those resource files. Typically, the properties being changed are to do with user interface labels and layouts, as well as a few other things such as default values for parameters and so on.
 
-If an element in the DTD has an equivilant property in OFX, the element will be the named with the same string that labels the property in the binary. For example the default property is labelled with "OfxParamPropDefault" in both cases.
+If an element in the DTD has an equivalent property in OFX, the element will be the named with the same string that labels the property in the binary. For example the default property is labelled with "OfxParamPropDefault" in both cases.
 
 The only attributes used on any element are there to identify the element, typically to associate it with a named object in the binary. This is the 'name' attribute. The only other attributes are to associate a host and a locale with the resource set.
 
@@ -50,7 +50,7 @@ A message redefinition is associated with the 'messageId' passed into the OfxMes
 
 A resource set is made up of parameter redefinitions, clip redefinitions, parameter hierarchy redefinitions and parameter page set redefinitions.
 
-Any parameter (except page and hierachy params) in the binaray may have certain properties overridden. Each parameter type has a corresponding element, for example the 2D integer parameter is specified via the 'OfxParamTypeInteger2D', the choice parameter by the 'OfxParamTypeChoice' element. There are 13 different elements, each of which corresponds to an OFX parameter type. The 'name' attribute of a parameter element is used to associate it with a specific parameter in the binary.
+Any parameter (except page and hierarchy params) in the binaray may have certain properties overridden. Each parameter type has a corresponding element, for example the 2D integer parameter is specified via the 'OfxParamTypeInteger2D', the choice parameter by the 'OfxParamTypeChoice' element. There are 13 different elements, each of which corresponds to an OFX parameter type. The 'name' attribute of a parameter element is used to associate it with a specific parameter in the binary.
 
 Each parameter element has it's own specific set of sub elements, as not all parameters support all properties.
 

--- a/include/ofxCore.h
+++ b/include/ofxCore.h
@@ -229,7 +229,7 @@ These are the actions passed to a plug-in's 'main' function
      returns one of the error codes where the host is allowed to attempt
      the action again
      -  the handle argument, being the global plug-in description handle, is
-     a valid handle from the end of a sucessful describe action until the
+     a valid handle from the end of a successful describe action until the
      end of the \ref kOfxActionUnload action (ie: the plug-in can cache it away
      without worrying about it changing between actions).
      -  \ref kOfxImageEffectActionDescribeInContext
@@ -276,7 +276,7 @@ These are the actions passed to a plug-in's 'main' function
 /** @brief
 
  This action is an action that may be passed to a plug-in
- instance from time to time in low memory situations. Instances recieving
+ instance from time to time in low memory situations. Instances receiving
  this action should destroy any data structures they may have and release
  the associated memory, they can later reconstruct this from the effect's
  parameter set and associated information.
@@ -436,7 +436,7 @@ These are the actions passed to a plug-in's 'main' function
      value of the object because it varies over time
 
      -  \ref kOfxPropTime
-     - the effect time at which the chang occured (for Image Effect Plugins only)
+     - the effect time at which the change occurred (for Image Effect Plugins only)
      -  \ref kOfxImageEffectPropRenderScale
      - the render scale currently being applied to any image fetched
      from a clip (for Image Effect Plugins only)
@@ -622,7 +622,7 @@ If this is not present, it is safe to assume that the version of the API is "1.0
 
 If false the effect currently has no interface, however this may be because the effect is loaded in a background render host, or it may be loaded on an interactive host that has not yet opened an editor for the effect.
 
-The output of an effect should only ever depend on the state of its parameters, not on the interactive flag. The interactive flag is more a courtesy flag to let a plugin know that it has an interace. If a plugin want's to have its behaviour dependant on the interactive flag, it can always make a secret parameter which shadows the state if the flag.
+The output of an effect should only ever depend on the state of its parameters, not on the interactive flag. The interactive flag is more a courtesy flag to let a plugin know that it has an interface. If a plugin wants to have its behaviour dependant on the interactive flag, it can always make a secret parameter which shadows the state if the flag.
 */
 #define kOfxPropIsInteractive "OfxPropIsInteractive"
 
@@ -669,7 +669,7 @@ This data pointer is unique to each plug-in instance, so two instances of the sa
     - Type - ASCII C string X 1
     - Property Set - on many objects (descriptors and instances), see \ref PropertiesByObject (read only)
 
-This property is used to label objects uniquely amoung objects of that type. It is typically set when a plugin creates a new object with a function that takes a name.
+This property is used to label objects uniquely among objects of that type. It is typically set when a plugin creates a new object with a function that takes a name.
 */
 #define kOfxPropName "OfxPropName"
 
@@ -740,7 +740,7 @@ The first dimension, if set, will the name of and SVG file, the second a PNG fil
     - Property Set - on many objects (descriptors and instances), see \ref PropertiesByObject. Typically readable and writable in most cases.
     - Default - initially ::kOfxPropName, but will be reset if ::kOfxPropLabel is changed.
 
-This is a shorter version of the label, typically 13 character glyphs or less. Hosts should use this if they have limitted display space for their object labels.
+This is a shorter version of the label, typically 13 character glyphs or less. Hosts should use this if they have limited display space for their object labels.
 */
 #define kOfxPropShortLabel "OfxPropShortLabel"
 

--- a/include/ofxDialog.h
+++ b/include/ofxDialog.h
@@ -68,7 +68,7 @@ The arguments to the action are...
   \arg outArgs - is redundant and set to null
 
    When the plugin receives this action it is thus safe to popup a dialog, or any other
-   taks that should be executed by the plugin in the UI thread.
+   tasks that should be executed by the plugin in the UI thread.
    It runs in the host's UI thread, which may differ from the main OFX processing thread.
    Plugin should return from this action when all Dialog interactions are done.
    At that point the host will continue again.

--- a/include/ofxImageEffect.h
+++ b/include/ofxImageEffect.h
@@ -317,7 +317,7 @@ These are the list of actions passed to an image effect plugin's main function. 
      For example ``OfxImageClipPropFrameRange_Source``. All these properties
      are multi-dimensional doubles, with the dimension is a multiple of
      two. Each pair of values indicates a continuous range of frames that
-     is needed on the given input. They are all initalised to the default value.
+     is needed on the given input. They are all initialised to the default value.
 
 
  @returns
@@ -650,7 +650,7 @@ This value will be the same for all instances of a plugin.
        - 0 - which means multiple instances can exist simultaneously,
        - 1 -  which means only one instance can exist at any one time.
 
-Some plugins, for whatever reason, may only be able to have a single instance in existance at any one time. This plugin property is used to indicate that.
+Some plugins, for whatever reason, may only be able to have a single instance in existence at any one time. This plugin property is used to indicate that.
 */
 #define kOfxImageEffectPluginPropSingleInstance "OfxImageEffectPluginPropSingleInstance"
 
@@ -660,7 +660,7 @@ Some plugins, for whatever reason, may only be able to have a single instance in
    - Property Set - plugin descriptor (read/write)
    - Default - ::kOfxImageEffectRenderInstanceSafe
    - Valid Values - This must be one of
-      - ::kOfxImageEffectRenderUnsafe - indicating that only a single 'render' call can be made at any time amoung all instances,
+      - ::kOfxImageEffectRenderUnsafe - indicating that only a single 'render' call can be made at any time among all instances,
       - ::kOfxImageEffectRenderInstanceSafe - indicating that any instance can have a single 'render' call at any one time,
       - ::kOfxImageEffectRenderFullySafe - indicating that any instance of a plugin can have multiple renders running simultaneously
 */
@@ -762,7 +762,7 @@ See \ref ImageEffectClipPreferences.
      - 1 - for a plugin, indicates that it needs to be sequentially rendered to be correct, for a host, indicates that it can always support sequential rendering of plugins that are sequentially rendered,
      - 2 - for a plugin, indicates that it is best to render sequentially, but will still produce correct results if not, for a host, indicates that it can sometimes render sequentially, and will have set ::kOfxImageEffectPropSequentialRenderStatus on the relevant actions
 
-Some effects have temporal dependancies, some information from from the rendering of frame N-1 is needed to render frame N correctly. This property is set by an effect to indicate such a situation. Also, some effects are more efficient if they run sequentially, but can still render correct images even if they do not, eg: a complex particle system.
+Some effects have temporal dependencies, some information from from the rendering of frame N-1 is needed to render frame N correctly. This property is set by an effect to indicate such a situation. Also, some effects are more efficient if they run sequentially, but can still render correct images even if they do not, eg: a complex particle system.
 
 During an interactive session a host may attempt to render a frame out of sequence (for example when the user scrubs the current time), and the effect needs to deal with such a situation as best it can to provide feedback to the user.
 
@@ -960,7 +960,7 @@ then the plugin can detect this via an identifier change and re-evaluate the cac
    - Default - 0 as an out argument to the ::kOfxImageEffectActionGetClipPreferences action
    - Valid Values - This must be one of...
      - 0 if the images can only be sampled at discreet times (eg: the clip is a sequence of frames),
-     - 1 if the images can only be sampled continuously (eg: the clip is infact an animating roto spline and can be rendered anywhen).
+     - 1 if the images can only be sampled continuously (eg: the clip is in fact an animating roto spline and can be rendered anywhen).
 
 If this is set to true, then the frame rate of a clip is effectively infinite, so to stop arithmetic
 errors the frame rate should then be set to 0.
@@ -1179,7 +1179,7 @@ Any clip that is not optional will \em always be connected during a render actio
    - Valid Values - This must be one of 0 or 1
 
 This property indicates whether a plugin will generate a different image from frame to frame, even if no parameters
-or input image changes. For example a generater that creates random noise pixel at each frame.
+or input image changes. For example a generator that creates random noise pixel at each frame.
  */
 #define kOfxImageEffectFrameVarying "OfxImageEffectFrameVarying"
 
@@ -1216,7 +1216,7 @@ This should be applied to any spatial parameters to position them correctly. Not
    - Valid Values - This must be one of 0 or 1
 
 This property indicates that the host provides the plug-in the option to render in Draft/Preview mode. This is useful for applications that must support fast scrubbing. These allow a plug-in to take short-cuts for improved performance when the situation allows and it makes sense, for example to generate thumbnails with effects applied. 
-For example switch to a cheaper interpolation type or rendering mode. A plugin should expect frames rendered in this manner that will not be stucked in host cache unless the cache is only used in the same draft situations.
+For example switch to a cheaper interpolation type or rendering mode. A plugin should expect frames rendered in this manner that will not be stuck in host cache unless the cache is only used in the same draft situations.
 If an host does not support that property a value of 0 is assumed.
 Also note that some hosts do implement kOfxImageEffectPropRenderScale - these two properties can be used independently. 
  */
@@ -1227,7 +1227,7 @@ Also note that some hosts do implement kOfxImageEffectPropRenderScale - these tw
     - Type - double X 2
     - Property Set - a plugin  instance (read only)
 
-The extent is the size of the 'output' for the current project. See \ref NormalisedCoordinateSystem for more infomation on the project extent.
+The extent is the size of the 'output' for the current project. See \ref NormalisedCoordinateSystem for more information on the project extent.
 
 The extent is in canonical coordinates and only returns the top right position, as the extent is always rooted at 0,0.
 
@@ -1244,7 +1244,7 @@ The size of a project is a sub set of the ::kOfxImageEffectPropProjectExtent. Fo
 
 The project size is in canonical coordinates.
 
-See \ref NormalisedCoordinateSystem for more infomation on the project extent.
+See \ref NormalisedCoordinateSystem for more information on the project extent.
  */
 #define kOfxImageEffectPropProjectSize "OfxImageEffectPropProjectSize"
 
@@ -1259,7 +1259,7 @@ For example for a PAL SD project that is in letterbox form, the project offset i
  
 The project offset is in canonical coordinates.
 
-See \ref NormalisedCoordinateSystem for more infomation on the project extent.
+See \ref NormalisedCoordinateSystem for more information on the project extent.
 */
 #define kOfxImageEffectPropProjectOffset "OfxImageEffectPropProjectOffset"
 
@@ -1286,8 +1286,8 @@ This contains the duration of the plug-in effect, in frames.
     - Property Set - a clip  instance (read only)
     - Valid Values - This must be one of
       - ::kOfxImageFieldNone  - the material is unfielded
-      - ::kOfxImageFieldLower - the material is fielded, with image rows 0,2,4.... occuring first in a frame
-      - ::kOfxImageFieldUpper - the material is fielded, with image rows line 1,3,5.... occuring first in a frame
+      - ::kOfxImageFieldLower - the material is fielded, with image rows 0,2,4.... occurring first in a frame
+      - ::kOfxImageFieldUpper - the material is fielded, with image rows line 1,3,5.... occurring first in a frame
  */
 #define kOfxImageClipPropFieldOrder "OfxImageClipPropFieldOrder"
 
@@ -1328,7 +1328,7 @@ The order of the values is x1, y1, x2, y2.
 X values are x1 <= X < x2 
 Y values are y1 <= Y < y2
 
-The ::kOfxImagePropBounds property contains the actuall addressable pixels in an image, which may be less than its full region of definition.
+The ::kOfxImagePropBounds property contains the actual addressable pixels in an image, which may be less than its full region of definition.
  */
 #define kOfxImagePropRegionOfDefinition "OfxImagePropRegionOfDefinition"
 
@@ -1680,7 +1680,7 @@ typedef struct OfxImageEffectSuiteV1 {
 			  const char *name,	 
 			  OfxPropertySetHandle *propertySet);
 
-  /** @brief Get the propery handle of the named input clip in the given instance 
+  /** @brief Get the property handle of the named input clip in the given instance 
    
    \arg imageEffect - an instance handle to the plugin
    \arg name        - name of the clip, previously used in a clip define call

--- a/include/ofxInteract.h
+++ b/include/ofxInteract.h
@@ -114,7 +114,7 @@ If a host does not support such a colour, it should return kOfxStatReplyDefault
    - Type - double X 2
    - Property Set - read only in argument to the ::kOfxInteractActionPenMotion, ::kOfxInteractActionPenDown and ::kOfxInteractActionPenUp actions
 
-This value passes the postion of the pen into an interact. This is in the interact's canonical coordinates.
+This value passes the position of the pen into an interact. This is in the interact's canonical coordinates.
  */
 #define kOfxInteractPropPenPosition "OfxInteractPropPenPosition"
 
@@ -123,7 +123,7 @@ This value passes the postion of the pen into an interact. This is in the intera
    - Type - int X 2
    - Property Set - read only in argument to the ::kOfxInteractActionPenMotion, ::kOfxInteractActionPenDown and ::kOfxInteractActionPenUp actions
 
-This value passes the postion of the pen into an interact. This is in the interact's openGL viewport coordinates, with 0,0 being at the bottom left.
+This value passes the position of the pen into an interact. This is in the interact's openGL viewport coordinates, with 0,0 being at the bottom left.
  */
 #define kOfxInteractPropPenViewportPosition "OfxInteractPropPenViewportPosition"
 
@@ -265,7 +265,7 @@ These are the list of actions passed to an interact's entry point function. For 
      - \ref kOfxPropEffectInstance a handle to the effect for which the interact has been,
      - \ref kOfxInteractPropPixelScale the scale factor to convert cannonical pixels to screen pixels
      - \ref kOfxInteractPropBackgroundColour the background colour of the application behind the current view
-     - \ref kOfxPropTime the effect time at which changed occured
+     - \ref kOfxPropTime the effect time at which changed occurred
      - \ref kOfxImageEffectPropRenderScale the render scale applied to any image fetched
 
  @param  outArgs is redundant and is set to NULL
@@ -295,9 +295,9 @@ These are the list of actions passed to an interact's entry point function. For 
      - \ref kOfxPropEffectInstance a handle to the effect for which the interact has been,
      - \ref kOfxInteractPropPixelScale the scale factor to convert cannonical pixels to screen pixels
      - \ref kOfxInteractPropBackgroundColour the background colour of the application behind the current view
-     - \ref kOfxPropTime the effect time at which changed occured
+     - \ref kOfxPropTime the effect time at which changed occurred
      - \ref kOfxImageEffectPropRenderScale the render scale applied to any image fetched
-     - \ref kOfxInteractPropPenPosition postion of the pen in,
+     - \ref kOfxInteractPropPenPosition position of the pen in,
      - \ref kOfxInteractPropPenViewportPosition position of the pen in,
      - \ref kOfxInteractPropPenPressure the pressure of the pen,
 
@@ -332,7 +332,7 @@ These are the list of actions passed to an interact's entry point function. For 
      - \ref kOfxPropEffectInstance a handle to the effect for which the interact has been,
      - \ref kOfxInteractPropPixelScale the scale factor to convert cannonical pixels to screen pixels
      - \ref kOfxInteractPropBackgroundColour the background colour of the application behind the current view
-     - \ref kOfxPropTime the effect time at which changed occured
+     - \ref kOfxPropTime the effect time at which changed occurred
      - \ref kOfxImageEffectPropRenderScale the render scale applied to any image fetched
      - \ref kOfxInteractPropPenPosition position of the pen in
      - \ref kOfxInteractPropPenViewportPosition position of the pen in
@@ -369,7 +369,7 @@ These are the list of actions passed to an interact's entry point function. For 
  - \ref kOfxPropEffectInstance a handle to the effect for which the interact has been,
  - \ref kOfxInteractPropPixelScale the scale factor to convert cannonical pixels to screen pixels
  - \ref kOfxInteractPropBackgroundColour the background colour of the application behind the current view
- - \ref kOfxPropTime the effect time at which changed occured
+ - \ref kOfxPropTime the effect time at which changed occurred
  - \ref kOfxImageEffectPropRenderScale the render scale applied to any image fetched
  - \ref kOfxInteractPropPenPosition position of the pen in
  - \ref kOfxInteractPropPenViewportPosition position of the pen in
@@ -406,7 +406,7 @@ These are the list of actions passed to an interact's entry point function. For 
      this may not have a UTF8 representation (eg: a return key)
      -  \ref kOfxPropKeyString UTF8 string representing a character key that was pressed, some
      keys have no UTF8 encoding, in which case this is ""
-     -  \ref kOfxPropTime the effect time at which changed occured
+     -  \ref kOfxPropTime the effect time at which changed occurred
      - \ref kOfxImageEffectPropRenderScale the render scale applied to any image fetched
 
  @param  outArgs is redundant and is set to NULL
@@ -439,7 +439,7 @@ These are the list of actions passed to an interact's entry point function. For 
      this may not have a UTF8 representation (eg: a return key)
      -  \ref kOfxPropKeyString UTF8 string representing a character key that was pressed, some
      keys have no UTF8 encoding, in which case this is ""
-     -  \ref kOfxPropTime the effect time at which changed occured
+     -  \ref kOfxPropTime the effect time at which changed occurred
      - \ref kOfxImageEffectPropRenderScale the render scale applied to any image fetched
 
  @param  outArgs is redundant and is set to NULL
@@ -472,7 +472,7 @@ These are the list of actions passed to an interact's entry point function. For 
      this may not have a UTF8 representation (eg: a return key)
      -  \ref kOfxPropKeyString UTF8 string representing a character key that was pressed, some
      keys have no UTF8 encoding, in which case this is ""
-     -  \ref kOfxPropTime the effect time at which changed occured
+     -  \ref kOfxPropTime the effect time at which changed occurred
      - \ref kOfxImageEffectPropRenderScale the render scale applied to any image fetched
 
  @param  outArgs is redundant and is set to NULL
@@ -503,7 +503,7 @@ These are the list of actions passed to an interact's entry point function. For 
      - \ref kOfxPropEffectInstance a handle to the effect for which the interact is being used on,
      - \ref kOfxInteractPropPixelScale the scale factor to convert cannonical pixels to screen pixels,
      - \ref kOfxInteractPropBackgroundColour the background colour of the application behind the current view
-     - \ref kOfxPropTime the effect time at which changed occured
+     - \ref kOfxPropTime the effect time at which changed occurred
      - \ref kOfxImageEffectPropRenderScale the render scale applied to any image fetched
 
  @param  outArgs is redundant and is set to NULL
@@ -528,7 +528,7 @@ These are the list of actions passed to an interact's entry point function. For 
      - \ref kOfxPropEffectInstance a handle to the effect for which the interact is being used on,
      - \ref kOfxInteractPropPixelScale the scale factor to convert cannonical pixels to screen pixels,
      - \ref kOfxInteractPropBackgroundColour the background colour of the application behind the current view
-     - \ref kOfxPropTime the effect time at which changed occured
+     - \ref kOfxPropTime the effect time at which changed occurred
      - \ref kOfxImageEffectPropRenderScale the render scale applied to any image fetched
 
  @param  outArgs is redundant and is set to NULL

--- a/include/ofxKeySyms.h
+++ b/include/ofxKeySyms.h
@@ -45,7 +45,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 This property represents a raw key press, it does not represent the 'character value' of the key. 
 
 This property is associated with a ::kOfxPropKeyString property, which encodes the UTF8
-value for the keypress/button press. Some keys (for example arrow keys) have no UTF8 equivalant.
+value for the keypress/button press. Some keys (for example arrow keys) have no UTF8 equivalent.
 
 Some keys, especially on non-english language systems, may have a UTF8 value, but \em not a keysym values, in these
 cases, the keysym will have a value of kOfxKey_Unknown, but the ::kOfxPropKeyString property will still be set with
@@ -62,8 +62,8 @@ the UTF8 value.
 
 This property represents the UTF8 encode value of a single key press by a user in an OFX interact.
 
-This property is associated with a ::kOfxPropKeySym which represents an integer value for the key press. Some keys (for example arrow keys) have no UTF8 equivalant, 
-in which case this is set to the empty string "", and the associate ::kOfxPropKeySym is set to the equivilant raw key press.
+This property is associated with a ::kOfxPropKeySym which represents an integer value for the key press. Some keys (for example arrow keys) have no UTF8 equivalent, 
+in which case this is set to the empty string "", and the associate ::kOfxPropKeySym is set to the equivalent raw key press.
 
 Some keys, especially on non-english language systems, may have a UTF8 value, but \em not a keysym values, in these
 cases, the keysym will have a value of kOfxKey_Unknown, but the ::kOfxPropKeyString property will still be set with
@@ -266,7 +266,7 @@ where the key has a UTF8 value which is not supported by the symbols below.
 
 
 /*
- * Auxilliary Functions; note the duplicate definitions for left and right
+ * Auxiliary Functions; note the duplicate definitions for left and right
  * function keys;  Sun keyboards and a few other manufactures have such
  * function key groups on the left and/or right sides of the keyboard.
  * We've not found a keyboard with more than 35 function keys total.

--- a/include/ofxMemory.h
+++ b/include/ofxMemory.h
@@ -48,15 +48,15 @@ For images, you should use the memory allocation functions in the image effect s
 typedef struct OfxMemorySuiteV1 {
   /** @brief Allocate memory.
       
-  \arg handle	- effect instance to assosciate with this memory allocation, or NULL.
+  \arg handle	- effect instance to associate with this memory allocation, or NULL.
   \arg nBytes        - the number of bytes to allocate
-  \arg allocatedData - a pointer to the return value. Allocated memory will be alligned for any use.
+  \arg allocatedData - a pointer to the return value. Allocated memory will be aligned for any use.
 
   This function has the host allocate memory using its own memory resources
   and returns that to the plugin.
 
   @returns
-  - ::kOfxStatOK the memory was sucessfully allocated
+  - ::kOfxStatOK the memory was successfully allocated
   - ::kOfxStatErrMemory the request could not be met and no memory was allocated
 
   */   
@@ -71,7 +71,7 @@ typedef struct OfxMemorySuiteV1 {
   This function frees any memory that was previously allocated via OfxMemorySuiteV1::memoryAlloc.
 
   @returns
-  - ::kOfxStatOK the memory was sucessfully freed
+  - ::kOfxStatOK the memory was successfully freed
   - ::kOfxStatErrBadHandle \e allocatedData was not a valid pointer returned by OfxMemorySuiteV1::memoryAlloc
 
   */   

--- a/include/ofxMessage.h
+++ b/include/ofxMessage.h
@@ -98,7 +98,7 @@ typedef struct OfxMessageSuiteV1 {
       \arg ...       - printf style varargs list to print
 
 \returns 
-  - ::kOfxStatOK - if the message was sucessfully posted 
+  - ::kOfxStatOK - if the message was successfully posted 
   - ::kOfxStatReplyYes - if the message was of type  kOfxMessageQuestion and the user reply yes
   - ::kOfxStatReplyNo - if the message was of type kOfxMessageQuestion and the user reply no
   - ::kOfxStatFailed - if the message could not be posted for some reason
@@ -130,7 +130,7 @@ typedef struct OfxMessageSuiteV2 {
       \arg ...       - printf style varargs list to print
 
       \returns 
-      - ::kOfxStatOK - if the message was sucessfully posted 
+      - ::kOfxStatOK - if the message was successfully posted 
       - ::kOfxStatReplyYes - if the message was of type  kOfxMessageQuestion and the user reply yes
       - ::kOfxStatReplyNo - if the message was of type kOfxMessageQuestion and the user reply no
       - ::kOfxStatFailed - if the message could not be posted for some reason
@@ -153,13 +153,13 @@ typedef struct OfxMessageSuiteV2 {
       \arg ...       - printf style varargs list to print
 
       \returns 
-        - ::kOfxStatOK - if the message was sucessfully posted 
+        - ::kOfxStatOK - if the message was successfully posted 
         - ::kOfxStatErrBadHandle - the handle was rubbish
         - ::kOfxStatFailed - if the message could not be posted for some reason
 
      Persistent messages are associated with an effect handle until explicitly cleared by an effect. So if an error message is posted the error state, and associated message will persist and be displayed on the effect appropriately. (eg: draw a node in red on a node based compostor and display the message when clicked on).
 
-     If \e messageType is error or warning, associated error states should be flagged on host applications. Posting an error message implies that the host cannot proceeed, a warning allows the host to proceed, whilst a simple message should have no stop anything.
+     If \e messageType is error or warning, associated error states should be flagged on host applications. Posting an error message implies that the host cannot proceed, a warning allows the host to proceed, whilst a simple message should have no stop anything.
    */
   OfxStatus (*setPersistentMessage)(void *handle,
                                     const char *messageType,
@@ -174,7 +174,7 @@ typedef struct OfxMessageSuiteV2 {
       \arg handle     - effect handle (descriptor or instance) 
 
       \returns 
-        - ::kOfxStatOK - if the message was sucessfully cleared
+        - ::kOfxStatOK - if the message was successfully cleared
         - ::kOfxStatErrBadHandle - the handle was rubbish
         - ::kOfxStatFailed - if the message could not be cleared for some reason
 

--- a/include/ofxMultiThread.h
+++ b/include/ofxMultiThread.h
@@ -67,7 +67,7 @@ typedef struct OfxMultiThreadSuiteV1 {
 
   \arg func The function to call in each thread.
   \arg nThreads The number of threads to launch
-  \arg customArg The paramter to pass to customArg of func in each thread.
+  \arg customArg The parameter to pass to customArg of func in each thread.
 
   This function will spawn nThreads separate threads of computation (typically one per CPU) 
   to allow something to perform symmetric multi processing. Each thread will call 'func' passing
@@ -77,12 +77,12 @@ typedef struct OfxMultiThreadSuiteV1 {
   how it waits for all the threads to return (busy wait, blocking, whatever).
 
   \e nThreads can be more than the value returned by multiThreadNumCPUs, however the threads will
-  be limitted to the number of CPUs returned by multiThreadNumCPUs.
+  be limited to the number of CPUs returned by multiThreadNumCPUs.
 
   This function cannot be called recursively.
 
   @returns
-  - ::kOfxStatOK, the function func has executed and returned sucessfully
+  - ::kOfxStatOK, the function func has executed and returned successfully
   - ::kOfxStatFailed, the threading function failed to launch
   - ::kOfxStatErrExists, failed in an attempt to call multiThread recursively,
 
@@ -130,7 +130,7 @@ typedef struct OfxMultiThreadSuiteV1 {
   \arg mutex - where the new handle is returned
   \arg count - initial lock count on the mutex. This can be negative.
 
-  Creates a new mutex with lockCount locks on the mutex intially set.    
+  Creates a new mutex with lockCount locks on the mutex initially set.    
 
   @returns
   - kOfxStatOK - mutex is now valid and ready to go
@@ -139,7 +139,7 @@ typedef struct OfxMultiThreadSuiteV1 {
 
   /** @brief Destroy a mutex
       
-  Destroys a mutex intially created by mutexCreate.
+  Destroys a mutex initially created by mutexCreate.
   
   @returns
   - kOfxStatOK - if it destroyed the mutex
@@ -149,9 +149,9 @@ typedef struct OfxMultiThreadSuiteV1 {
 
   /** @brief Blocking lock on the mutex
 
-  This trys to lock a mutex and blocks the thread it is in until the lock suceeds. 
+  This tries to lock a mutex and blocks the thread it is in until the lock succeeds. 
 
-  A sucessful lock causes the mutex's lock count to be increased by one and to block any other calls to lock the mutex until it is unlocked.
+  A successful lock causes the mutex's lock count to be increased by one and to block any other calls to lock the mutex until it is unlocked.
   
   @returns
   - kOfxStatOK - if it got the lock
@@ -173,7 +173,7 @@ typedef struct OfxMultiThreadSuiteV1 {
 
   This attempts to lock a mutex, if it cannot, it returns and says so, rather than blocking.
 
-  A sucessful lock causes the mutex's lock count to be increased by one, if the lock did not suceed, the call returns immediately and the lock count remains unchanged.
+  A successful lock causes the mutex's lock count to be increased by one, if the lock did not succeed, the call returns immediately and the lock count remains unchanged.
 
   @returns
   - kOfxStatOK - if it got the lock

--- a/include/ofxNatron.h
+++ b/include/ofxNatron.h
@@ -8,7 +8,7 @@
  It indicates whether the host is Natron as another mean than just the host name.
  This was added because it may be required to activate certain plug-ins by changing the host-name 
  (since some plug-ins don't allow to be loaded on any host)
- but to keep some other functionnalities specific to the Natron extensions working.
+ but to keep some other functionalities specific to the Natron extensions working.
  
 Valid values:
  - 0: Indicates that the host is not Natron
@@ -390,7 +390,7 @@ This is a property on parameters of type ::kOfxParamTypeChoice, and tells the ch
  - Default - 0
  - Valid Values - 0 or 1
  When set to 1, the parameter is specific to an effect instance of the plug-in and should have a
- unique representation for each instance. See descripton of kNatronOfxImageEffectContextTracker for more details
+ unique representation for each instance. See description of kNatronOfxImageEffectContextTracker for more details
  on multiple instances and difference between shared and specific parameters.
  */
 #define kNatronOfxParamPropIsInstanceSpecific "NatronOfxParamPropIsInstanceSpecific"
@@ -544,7 +544,7 @@ This is a property on parameters of type ::kOfxParamTypeChoice, and tells the ch
          2 meaning that the selection is finilized by the user (i.e: during pen up)
     The property kNatronOfxImageEffectSelectionRectangle will be updated prior to calling the kOfxActionInstanceChanged action for this parameter by the host, indicating the region covered by the selection rectangle. 
 
- 8) The host application cursor can be controled by the plug-in via a secret String parameter with the name kNatronOfxParamCursorName. If this parameter is found, the host should display a cursor depending on the value of this parameter.  The value of the parameter should be the name of the cursor. Several default cursor can be made available by the host as advertised by the kNatronOfxImageEffectPropDefaultCursors property. The plug-in may also embed custom cursors as PNG files located in the Resources directory of the plug-in bundle. To specify one the image in the plug-in bundle as an icon, you may set the value of this parameter to the filename of the image without any leading path. This is up to the host to figure out the path to the plug-in bundle Resources directory.
+ 8) The host application cursor can be controlled by the plug-in via a secret String parameter with the name kNatronOfxParamCursorName. If this parameter is found, the host should display a cursor depending on the value of this parameter.  The value of the parameter should be the name of the cursor. Several default cursor can be made available by the host as advertised by the kNatronOfxImageEffectPropDefaultCursors property. The plug-in may also embed custom cursors as PNG files located in the Resources directory of the plug-in bundle. To specify one the image in the plug-in bundle as an icon, you may set the value of this parameter to the filename of the image without any leading path. This is up to the host to figure out the path to the plug-in bundle Resources directory.
      Whenever an event is sent to overlay interacts (PenDown, PenMotion, PenUp, KeyDown, KeyUp, KeyRepeat, GainFocus, LoseFocus, the OFX Host should set the cursor to the one of the first interact which catches the event by returning kOfxStatOK to the corresponding action. If no overlay interact returns kOfxStatOK, the cursor should be set to the default cursor.
  
  9) It may be useful to show a dialog to a user to request a little information before doing a task such as an analysis.
@@ -999,7 +999,7 @@ says:
 ////////////////////////////////////////////////////////////////////////////////
 ////////////////////////////////////////////////////////////////////////////////
 // Extensions for image effects that can return a distortion function rather
-// than an image. A distortion function gost from a 2D distorted position in
+// than an image. A distortion function ghost from a 2D distorted position in
 // canonical coordinates in the output distorted image to the undistorted
 // position in canonical coordinates in the source image.
 
@@ -1045,7 +1045,7 @@ says:
  - The Render Action
  - The Begin Sequence Render Action
  - The End Sequence Render Action
- The effect only needs a single image frome the clip named in the out args of this action
+ The effect only needs a single image from the clip named in the out args of this action
 
 
  For maximum flexibility, a plug-in must be allowed to fetch images inside this action, so as to be
@@ -1082,23 +1082,23 @@ host may optimize the concatenation of 3x3 matrix into a single matrix. This is 
  -  kOfxPropInverseDistortionFunction (pointer x1): A pointer to the distortion function itself that the host should call. 
  The function has the signature described below (OfxDistortionFunctionV1)
 
- -  kOfxPropInverseDistortionFunctionData (pointer x1) : Pointer to datas owned by the plug-in that should be passed back as customData
+ -  kOfxPropInverseDistortionFunctionData (pointer x1) : Pointer to data owned by the plug-in that should be passed back as customData
  to the OfxDistortionFunctionV1 function. This can contain parameter values or STMaps or anything custom to the plug-in.
- These datas will be freed by the kOfxPropInverseDistortionFunctionFreeData speficied below once the host does not need them anymore.
- Note that the host may cache these datas away and it is important to hint the host about the size these datas holds in the host cache.
+ This data will be freed by the kOfxPropInverseDistortionFunctionFreeData specified below once the host does not need them anymore.
+ Note that the host may cache this data away and it is important to hint the host about the size this data holds in the host cache.
 
- - kOfxPropInverseDistortionFunctionDataSize (int x1): An estimated size in bytes of the memory held by the datas pointed to by kOfxPropInverseDistortionFunctionData.
- The host may cache these datas away and it is important to hint the host about the size these datas holds in the host cache.
+ - kOfxPropInverseDistortionFunctionDataSize (int x1): An estimated size in bytes of the memory held by the data pointed to by kOfxPropInverseDistortionFunctionData.
+ The host may cache this data away and it is important to hint the host about the size this data holds in the host cache.
  This should not overflow an integer size.
 
  -  kOfxPropInverseDistortionDataFreeFunction (pointer x1): Pointer to a function called by the host when the concatenation is done to free
-the datas pointed to by kOfxPropInverseDistortionFunctionData
+the data pointed to by kOfxPropInverseDistortionFunctionData
  
 
 
  @returns
  - ::kOfxStatDefault - don't attempt to any of the out args, but render the image as per normal,
- - ::kOfxStatOK - the transfrom and clip name were set and can be used to modify the named image appropriately,
+ - ::kOfxStatOK - the transform and clip name were set and can be used to modify the named image appropriately,
 
  */
 
@@ -1130,9 +1130,9 @@ the datas pointed to by kOfxPropInverseDistortionFunctionData
 
 
 /*
-@brief Property that hints the host about the total size of the datas pointed to by kOfxPropInverseDistortionFunctionData. If these datas contain buffers or images
+@brief Property that hints the host about the total size of the data pointed to by kOfxPropInverseDistortionFunctionData. If this data contains buffers or images
  they should be summed up.
- The host may cache these datas away and it is important to hint the host about the size these datas holds in the host cache.
+ The host may cache this data away and it is important to hint the host about the size this data holds in the host cache.
  This should not overflow an integer size.
  
  - Type - Int x1
@@ -1154,8 +1154,8 @@ the datas pointed to by kOfxPropInverseDistortionFunctionData
 
 /**
  @brief Prototype of the distortion passed to the kOfxPropInverseDistortionFunction property. It takes in input the distorted position and should output the
- undistorted position, both in canonical coordinates. Optionnally the Jacobian may be output.
- @param customData These are custom datas that were returned by the plug-in in the kOfxImageEffectActionGetInverseDistortion action in kOfxPropInverseDistortionFunctionData
+ undistorted position, both in canonical coordinates. Optionally the Jacobian may be output.
+ @param customData These are custom data that were returned by the plug-in in the kOfxImageEffectActionGetInverseDistortion action in kOfxPropInverseDistortionFunctionData
  @param wantsJacobian True if the caller would like the function to return a Jacobian, if possible. Note that the function may not return a Jacobian
  even if it was asked for, in which case the caller will have to compute it using for example finite differences.
  @param gotJaboian True if the jacobian was computed and set in output. If wantsJacobian is set to false, this parameter may be NULL.

--- a/include/ofxOld.h
+++ b/include/ofxOld.h
@@ -125,7 +125,7 @@ V1.4: Removed
  */
 #define kOfxParamDoubleTypeNormalisedXY  "OfxParamDoubleTypeNormalisedXY"
 
-/** @brief value for the ::kOfxParamPropDoubleType property, indicating normalisation to the X and Y dimension for a 2D param that can be interpretted as an absolute spatial position. See \ref ::kOfxParamPropDoubleType. 
+/** @brief value for the ::kOfxParamPropDoubleType property, indicating normalisation to the X and Y dimension for a 2D param that can be interpreted as an absolute spatial position. See \ref ::kOfxParamPropDoubleType. 
 -- ofxParam.h
 @deprecated - V1.3: Deprecated in favour of ::kOfxParamDoubleTypeXYAbsolute 
 V1.4: Removed

--- a/include/ofxParam.h
+++ b/include/ofxParam.h
@@ -181,7 +181,7 @@ Hosts that do not support paged parameter layout should set this to zero.
 */
 #define kOfxParamHostPropMaxPages "OfxParamHostPropMaxPages"
 
-/** @brief This indicates the number of parameter rows and coloumns on a page.
+/** @brief This indicates the number of parameter rows and columns on a page.
 
     - Type - int X 2
     - Property Set - host descriptor (read only)
@@ -352,7 +352,7 @@ Note the spelling error in the string value.
 */
 #define kOfxParamPropPersistent "OfxParamPropPersistant"
 
-/** @brief Flags whether changing a parameter's value forces an evalution (ie: render),
+/** @brief Flags whether changing a parameter's value forces an evaluation (ie: render),
 
     - Type - int x 1
     - Property Set - plugin parameter descriptor (read/write) and instance (read/write only)
@@ -454,8 +454,8 @@ The exact type and dimension is dependant on the type of the parameter. These ar
    - Property Set - 1D, 2D and 3D float plugin parameter descriptor (read/write) and instance (read only),
    - Valid Values -This must be one of
       - ::kOfxParamDoubleTypePlain - parameter has no special interpretation,
-      - ::kOfxParamDoubleTypeAngle - parameter is to be interpretted as an angle,
-      - ::kOfxParamDoubleTypeScale - parameter is to be interpretted as a scale factor,
+      - ::kOfxParamDoubleTypeAngle - parameter is to be interpreted as an angle,
+      - ::kOfxParamDoubleTypeScale - parameter is to be interpreted as a scale factor,
       - ::kOfxParamDoubleTypeTime  - parameter represents a time value (1D only),
       - ::kOfxParamDoubleTypeAbsoluteTime  - parameter represents an absolute time value (1D only),
 
@@ -471,7 +471,7 @@ as to the interface of the parameter.
 */
 #define kOfxParamPropDoubleType "OfxParamPropDoubleType"
 
-/** @brief value for the ::kOfxParamPropDoubleType property, indicating the parameter has no special interpretation and should be interpretted as a raw numeric value. */
+/** @brief value for the ::kOfxParamPropDoubleType property, indicating the parameter has no special interpretation and should be interpreted as a raw numeric value. */
 #define kOfxParamDoubleTypePlain "OfxParamDoubleTypePlain"
 
 /** @brief value for the ::kOfxParamPropDoubleType property, indicating the parameter is to be interpreted as a scale factor. See \ref ::kOfxParamPropDoubleType. */
@@ -699,7 +699,7 @@ Setting this will also reset :;kOfxParamPropDisplayMax.
     - Property Set - plugin parameter descriptor (read/write) and instance (read/write),
     - Default - the smallest possible value corresponding to the parameter type (eg: INT_MIN for an integer, -DBL_MAX for a double parameter)
 
-If a user interface represents a parameter with a slider or similar, this should be the minumum bound on that slider.
+If a user interface represents a parameter with a slider or similar, this should be the minimum bound on that slider.
 */
 #define kOfxParamPropDisplayMin "OfxParamPropDisplayMin"
 
@@ -1172,7 +1172,7 @@ changes a keyframe.  The keyframe indices will not change within a single action
   /** @brief Deletes all keyframes from a parameter.
 
   \arg paramHandle parameter handle to delete the keys from
-  \arg name      parameter to delete the keyframes frome is
+  \arg name      parameter to delete the keyframes from is
 
   V1.3: This function can be called the ::kOfxActionInstanceChanged action and during image effect analysis render passes.
   V1.4: This function can be called the ::kOfxActionInstanceChanged action 

--- a/include/ofxParametricParam.h
+++ b/include/ofxParametricParam.h
@@ -87,7 +87,7 @@ This indicates the dimension of the parametric param.
     - Property Set - parametric param descriptor (read/write) and instance (read only)
     - default - unset, 
     - Value Values - three values for each dimension (see ::kOfxParamPropParametricDimension)
-      being interpretted as R, G and B of the colour for each curve drawn in the UI.
+      being interpreted as R, G and B of the colour for each curve drawn in the UI.
 
 This sets the colour of a parametric param curve drawn a host user interface. A colour triple
 is needed for each dimension of the oparametric param. 
@@ -305,7 +305,7 @@ typedef struct OfxParametricParameterSuiteV1 {
  has a left and right derivative which are computed by the host given an interpolation mode set on the control point.
  The interpolation mode is valid for a control point up to another. The first control point left derivative
  and the last control point right derivative cannot have a specific interpolation mode.
- The interpolation mode can be controled by the function parametricParamSetNthControlPoint and parametricParamAddControlPoint.
+ The interpolation mode can be controlled by the function parametricParamSetNthControlPoint and parametricParamAddControlPoint.
  In return the host will set the derivatives in the function parametricParamGetNControlPoints.
  A host can advertise the types of interpolation it supports among default interpolation modes.
  A plug-in is then free to give the host any interpolation that it recognizes. Failure to provide a known interpolation
@@ -392,19 +392,19 @@ typedef OfxStatus (OfxParametricParamCustomInterpFuncV1)(OfxParamSetHandle insta
                                                          OfxPropertySetHandle inArgs,
                                                          OfxPropertySetHandle outArgs);
 
-/** @brief A double 2D indicating the time of the previous and next control points surrounding the parametric time at which the interpolation is occuring.
+/** @brief A double 2D indicating the time of the previous and next control points surrounding the parametric time at which the interpolation is occurring.
   - Type - Double X 2
   - Property Set - inArgs of the OfxParametricParamCustomInterpFuncV1 function
  */
 #define kOfxParametricParamCustomInterpInterpolationTime "OfxParametricParamCustomInterpInterpolationTime"
 
-/** @brief A double 2D indicating the value of the previous and next control points surrounding the parametric time at which the interpolation is occuring.
+/** @brief A double 2D indicating the value of the previous and next control points surrounding the parametric time at which the interpolation is occurring.
    - Type - Double X 2
    - Property Set - inArgs of the OfxParametricParamCustomInterpFuncV1 function
 */
 #define kOfxParametricParamCustomInterpInterpolationValue "OfxParametricParamCustomInterpInterpolationValue"
 
-/** @brief A int 1D indicating the index of the previous control point relative to the parametric time at which the interpolation is occuring.
+/** @brief A int 1D indicating the index of the previous control point relative to the parametric time at which the interpolation is occurring.
   - Type - int X 1
   - Property Set - inArgs of the OfxParametricParamCustomInterpFuncV1 function
 */

--- a/include/ofxProperty.h
+++ b/include/ofxProperty.h
@@ -115,7 +115,7 @@ typedef struct OfxPropertySuiteV1 {
 
       \arg properties is the handle of the thing holding the property
       \arg property is the string labelling the property
-      \arg count is the number of values we are setting in that property (ie: indicies 0..count-1)
+      \arg count is the number of values we are setting in that property (ie: indices 0..count-1)
       \arg value is a pointer to an array of property values
 
       @returns
@@ -131,7 +131,7 @@ typedef struct OfxPropertySuiteV1 {
 
       \arg properties is the handle of the thing holding the property
       \arg property is the string labelling the property
-      \arg count is the number of values we are setting in that property (ie: indicies 0..count-1)
+      \arg count is the number of values we are setting in that property (ie: indices 0..count-1)
       \arg value is a pointer to an array of property values
 
       @returns
@@ -147,7 +147,7 @@ typedef struct OfxPropertySuiteV1 {
 
       \arg properties is the handle of the thing holding the property
       \arg property is the string labelling the property
-      \arg count is the number of values we are setting in that property (ie: indicies 0..count-1)
+      \arg count is the number of values we are setting in that property (ie: indices 0..count-1)
       \arg value is a pointer to an array of property values
 
       @returns
@@ -164,7 +164,7 @@ typedef struct OfxPropertySuiteV1 {
 
       \arg properties is the handle of the thing holding the property
       \arg property is the string labelling the property
-      \arg count is the number of values we are setting in that property (ie: indicies 0..count-1)
+      \arg count is the number of values we are setting in that property (ie: indices 0..count-1)
       \arg value is a pointer to an array of property values
 
       @returns
@@ -243,7 +243,7 @@ typedef struct OfxPropertySuiteV1 {
 
       \arg properties is the handle of the thing holding the property
       \arg property is the string labelling the property
-      \arg count is the number of values we are getting of that property (ie: indicies 0..count-1)
+      \arg count is the number of values we are getting of that property (ie: indices 0..count-1)
       \arg value is a pointer to an array of where we will return the property values
 
       @returns
@@ -258,7 +258,7 @@ typedef struct OfxPropertySuiteV1 {
 
       \arg properties is the handle of the thing holding the property
       \arg property is the string labelling the property
-      \arg count is the number of values we are getting of that property (ie: indicies 0..count-1)
+      \arg count is the number of values we are getting of that property (ie: indices 0..count-1)
       \arg value is a pointer to an array of where we will return the property values
 
       See the note \ref ArchitectureStrings for how to deal with strings.
@@ -275,7 +275,7 @@ typedef struct OfxPropertySuiteV1 {
 
       \arg properties is the handle of the thing holding the property
       \arg property is the string labelling the property
-      \arg count is the number of values we are getting of that property (ie: indicies 0..count-1)
+      \arg count is the number of values we are getting of that property (ie: indices 0..count-1)
       \arg value is a pointer to an array of where we will return the property values
 
       @returns
@@ -290,7 +290,7 @@ typedef struct OfxPropertySuiteV1 {
 
       \arg properties is the handle of the thing holding the property
       \arg property is the string labelling the property
-      \arg count is the number of values we are getting of that property (ie: indicies 0..count-1)
+      \arg count is the number of values we are getting of that property (ie: indices 0..count-1)
       \arg value is a pointer to an array of where we will return the property values
 
       @returns

--- a/include/ofxTimeLine.h
+++ b/include/ofxTimeLine.h
@@ -49,7 +49,7 @@ typedef struct OfxTimeLineSuiteV1 {
       This function returns the current time value of the timeline associated with the effect instance.
 
       @returns
-      - ::kOfxStatOK - the time enquiry was sucessful
+      - ::kOfxStatOK - the time enquiry was successful
       - ::kOfxStatFailed - the enquiry failed for some host specific reason
       - ::kOfxStatErrBadHandle - the effect handle was invalid
   */
@@ -65,7 +65,7 @@ typedef struct OfxTimeLineSuiteV1 {
       if the output of the effect is being viewed).
 
       @returns
-      - ::kOfxStatOK - the time was changed sucessfully, will all side effects if the change completed
+      - ::kOfxStatOK - the time was changed successfully, will all side effects if the change completed
       - ::kOfxStatFailed - the change failed for some host specific reason
       - ::kOfxStatErrBadHandle - the effect handle was invalid
       - ::kOfxStatErrValue - the time was an illegal value       
@@ -81,7 +81,7 @@ typedef struct OfxTimeLineSuiteV1 {
       This function
 
       @returns
-      - ::kOfxStatOK - the time enquiry was sucessful
+      - ::kOfxStatOK - the time enquiry was successful
       - ::kOfxStatFailed - the enquiry failed for some host specific reason
       - ::kOfxStatErrBadHandle - the effect handle was invalid
   */

--- a/website/htdocs/Documentation/index.html
+++ b/website/htdocs/Documentation/index.html
@@ -13,7 +13,7 @@
 <para>This is documentation collection for all versions of the OFX Image Processing API. The documentation is available in two basic forms..
 </para>
 <ol>
-  <li>Doxgen auto-generated documentation extracted from the headers of the API,</li>
+  <li>Doxygen auto-generated documentation extracted from the headers of the API,</li>
   <li>A docbook reference manual.</li>
 </ol>
 

--- a/website/htdocs/index.html
+++ b/website/htdocs/index.html
@@ -89,7 +89,7 @@ wish to use it.</li>
       </ul>
       <h3 style="text-decoration: underline;">Ownership</h3>
 Initially owned by <a href="http://www.thefoundry.co.uk">The Foundry</a> and released under a BSD style license, the API 
-was transfered to <a href="http://www.openeffects.org">The Open Effects Association</a> in 2009. 
+was transferred to <a href="http://www.openeffects.org">The Open Effects Association</a> in 2009. 
 <br>
 The Association is a not for profit UK Limited Company controlled by various organisation active in developing software
 for visual effects.


### PR DESCRIPTION
Found via `codespell -i 3 -w -L amin,cannonical,halfs,parmter,paramter,paramters,objext -S `