### PR TITLE
Move UNIX and WINDOWS platform defines to separate header

### DIFF
--- a/HostSupport/include/ofxhBinary.h
+++ b/HostSupport/include/ofxhBinary.h
@@ -32,15 +32,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <string>
 #include <iostream>
 
-#if defined(_WIN32) || defined(_WIN64)
-#ifndef WINDOWS
-#define WINDOWS
-#endif
-#elif defined(__linux__) || defined(__FreeBSD__) || defined( __APPLE__) || defined(unix) || defined(__unix) || defined(_XOPEN_SOURCE) || defined(_POSIX_SOURCE)
-#define UNIX
-#else
-#error cannot detect operating system
-#endif
+#include "ofxhPlatformDefines.h"
 
 #if defined(UNIX)
 #include <dlfcn.h>

--- a/HostSupport/include/ofxhPlatformDefines.h
+++ b/HostSupport/include/ofxhPlatformDefines.h
@@ -1,0 +1,14 @@
+#ifndef OFXH_PLATFORM_DEFINES_H
+#define OFXH_PLATFORM_DEFINES_H
+
+#if defined(_WIN32) || defined(_WIN64)
+#ifndef WINDOWS
+#define WINDOWS
+#endif
+#elif defined(__linux__) || defined(__FreeBSD__) || defined( __APPLE__) || defined(unix) || defined(__unix) || defined(_XOPEN_SOURCE) || defined(_POSIX_SOURCE)
+#define UNIX
+#else
+#error cannot detect operating system
+#endif
+
+#endif

--- a/HostSupport/include/ofxhUtilities.h
+++ b/HostSupport/include/ofxhUtilities.h
@@ -39,6 +39,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <cmath> // isnan, std::isnan
 
 #include "ofxCore.h"
+#include "ofxhPlatformDefines.h"
 
 // macro that intercepts any exception that passes through a plugin's entry point, and transforms it into a message on the host using Host::vmessage()
 #define CatchAllSetStatus(stat,host,plugin,msg)                         \

--- a/HostSupport/src/ofxhUtilities.cpp
+++ b/HostSupport/src/ofxhUtilities.cpp
@@ -29,6 +29,8 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include "ofxCore.h"
 #include "ofxhUtilities.h"
+#include "ofxhPlatformDefines.h"
+
 #ifdef WINDOWS
 #include <windows.h>
 #endif


### PR DESCRIPTION
Moving platform #defines to a header file so they can be reused by other headers. This fixes build issues with ofxhUtilities.cpp on Windows where a file that includes ofxhBinary.h and ofxhUtilities.h will be able to call utf8_to_utf16(), but will fail to link. This happens because ofxhUtilities.o doesn't have the utf8_to_utf16() implementation because WINDOWS was not defined. This issue was discovered while doing a debug build of openfx-misc on Windows. The DebugProxy plugin failed to link because of this issue.

This change fixes the linking issue by making sure that WINDOWS is defined properly when ofxhUtilities.h is included and ensures that it is defined when ofxhUtilities.cpp is built.