### PR TITLE
destroyInstanceAction always returns `kOfxStatFailed` !!!

### DIFF
--- a/HostSupport/src/ofxhImageEffect.cpp
+++ b/HostSupport/src/ofxhImageEffect.cpp
@@ -1016,7 +1016,7 @@ namespace OFX {
             const char* id = ofxp->pluginIdentifier;
             std::cout << "OFX: "<<id<<"("<<(void*)ofxp<<")->"<<kOfxActionDestroyInstance<<"()"<<std::endl;
 #         endif
-          OfxStatus st = mainEntry(kOfxActionDestroyInstance,this->getHandle(),0,0);
+          st = mainEntry(kOfxActionDestroyInstance,this->getHandle(),0,0);
 #         ifdef OFX_DEBUG_ACTIONS
             std::cout << "OFX: "<<id<<"("<<(void*)ofxp<<")->"<<kOfxActionDestroyInstance<<"()->"<<StatStr(st)<<std::endl;
 #         endif


### PR DESCRIPTION
Local variable `OfxStatus st` hide the `st` variable used to indicate status on return.

Use top `st` variable to avoid always returning `kOfxStatFailed`